### PR TITLE
perf: increase DAG timeout to 12 hours

### DIFF
--- a/DAG-insert-elk-sirene.py
+++ b/DAG-insert-elk-sirene.py
@@ -53,7 +53,7 @@ with DAG(
     default_args=default_args,
     schedule_interval="0 23 10 * *",
     start_date=days_ago(10),
-    dagrun_timeout=timedelta(minutes=60 * 8),
+    dagrun_timeout=timedelta(minutes=60 * 12),
     tags=["siren"],
 ) as dag:
     get_colors = PythonOperator(


### PR DESCRIPTION
Staging timeout after 8 hours. Increase timeout to 12 hours.