### PR TITLE
Break big documents into smaller ones

### DIFF
--- a/elasticsearch/indexing_unite_legale.py
+++ b/elasticsearch/indexing_unite_legale.py
@@ -1,5 +1,4 @@
 import logging
-import itertools
 
 from dag_datalake_sirene.elasticsearch.mapping_sirene_index import (
     ElasticsearchSireneIndex,
@@ -33,8 +32,8 @@ def elasticsearch_doc_siren_generator(data):
                 etablissements_left = etablissements_left - 100
                 etablissements_indexed += 100
                 yield ElasticsearchSireneIndex(
-                    meta={"id": f"{smaller_document['siren']}-{counter}"},
-                    **seperated_document,
+                    meta={"id": f"{smaller_document['siren']}-{etablissements_indexed}"},
+                    **smaller_document,
                 ).to_dict(include_meta=True)
         # Otherwise (the docuemnt has less than 100 établissements), index document
         # as is

--- a/elasticsearch/indexing_unite_legale.py
+++ b/elasticsearch/indexing_unite_legale.py
@@ -14,7 +14,7 @@ def elasticsearch_doc_siren_generator(data):
     for index, document in enumerate(data):
         etablissements_count = len(document["etablissements"])
         # If ` unité légale` had more than 100 `établissements`, the main document is
-        # seperated into smaller documents consisting of 100 établissements each
+        # separated into smaller documents consisting of 100 établissements each
         if etablissements_count > 100:
             smaller_document = document.copy()
             etablissements = document["etablissements"]
@@ -32,7 +32,9 @@ def elasticsearch_doc_siren_generator(data):
                 etablissements_left = etablissements_left - 100
                 etablissements_indexed += 100
                 yield ElasticsearchSireneIndex(
-                    meta={"id": f"{smaller_document['siren']}-{etablissements_indexed}"},
+                    meta={
+                        "id": f"{smaller_document['siren']}-{etablissements_indexed}"
+                    },
                     **smaller_document,
                 ).to_dict(include_meta=True)
         # Otherwise, (the document has less than 100 établissements), index document

--- a/elasticsearch/indexing_unite_legale.py
+++ b/elasticsearch/indexing_unite_legale.py
@@ -35,7 +35,7 @@ def elasticsearch_doc_siren_generator(data):
                     meta={"id": f"{smaller_document['siren']}-{etablissements_indexed}"},
                     **smaller_document,
                 ).to_dict(include_meta=True)
-        # Otherwise (the docuemnt has less than 100 établissements), index document
+        # Otherwise, (the document has less than 100 établissements), index document
         # as is
         else:
             yield ElasticsearchSireneIndex(

--- a/labels/departements.py
+++ b/labels/departements.py
@@ -1,12 +1,12 @@
 # Create list of departement zip codes
 all_deps = [
+    *"-7510".join(list(str(x) for x in range(0, 10))).split("-")[1:],
+    *"-751".join(list(str(x) for x in range(9, 21))).split("-")[1:],
+    *["971", "972", "973", "974", "976", "98"],
     *"-0".join(list(str(x) for x in range(0, 10))).split("-")[1:],
     *list(str(x) for x in range(10, 20)),
     *["2A", "2B"],
     *list(str(x) for x in range(21, 96)),
-    *"-7510".join(list(str(x) for x in range(0, 10))).split("-")[1:],
-    *"-751".join(list(str(x) for x in range(9, 21))).split("-")[1:],
-    *["971", "972", "973", "974", "976", "98"],
     *[""],
 ]
 # Remove Paris zip code


### PR DESCRIPTION
related to https://github.com/etalab/annuaire-entreprises-search-api/issues/148
Searching in Elasticsearch is very slow when big documents are concerned (e.g `la poste`). To better the performance, we separate the larger documents (mora than a 100 établissements) into smaller ones, then collapse them suing `siren` number in the API front.