### PR TITLE
Utiliser le `code postal` dans l'adresse à la place du `code commune`

### DIFF
--- a/data_enrichment.py
+++ b/data_enrichment.py
@@ -93,7 +93,7 @@ def format_adresse_complete(
     libelle_commune,
     libelle_cedex,
     distribution_speciale,
-    commune,
+    code_postal,
     cedex,
     libelle_commune_etranger,
     libelle_pays_etranger,
@@ -111,13 +111,13 @@ def format_adresse_complete(
         if column:
             adresse = adresse + " " + column
     if cedex is None:
-        if commune is None:
+        if code_postal is None:
             adresse = adresse
         else:
             adresse = (
                 adresse
                 + " "
-                + get_empty_string_if_none(commune)
+                + get_empty_string_if_none(code_postal)
                 + " "
                 + get_empty_string_if_none(libelle_commune)
             )
@@ -268,7 +268,7 @@ def format_etablissements_and_complements(list_etablissements_sqlite, nom_comple
             etablissement["libelle_commune"],
             etablissement["libelle_cedex"],
             etablissement["distribution_speciale"],
-            etablissement["commune"],
+            etablissement["code_postal"],
             etablissement["cedex"],
             etablissement["libelle_commune_etranger"],
             etablissement["libelle_pays_etranger"],
@@ -317,7 +317,7 @@ def format_siege_unite_legale(siege):
         siege["libelle_commune"],
         siege["libelle_cedex"],
         siege["distribution_speciale"],
-        siege["commune"],
+        siege["code_postal"],
         siege["cedex"],
         siege["libelle_commune_etranger"],
         siege["libelle_pays_etranger"],

--- a/elasticsearch/mapping_sirene_index.py
+++ b/elasticsearch/mapping_sirene_index.py
@@ -88,8 +88,9 @@ class ElasticsearchEtablissementIndex(InnerDoc):
     cedex_2 = Text()
     code_pays_etranger = Text()
     code_pays_etranger_2 = Text()
-    code_postal = Keyword()
-    commune = Keyword()
+    code_postal = Text(analyzer=annuaire_analyzer)
+    # Using analyzer to be able to search using multi-match
+    commune = Text(analyzer=annuaire_analyzer)
     commune_2 = Text()
     concat_enseigne_adresse_siren_siret = Text(
         analyzer=annuaire_analyzer, fields={"keyword": Keyword()}


### PR DESCRIPTION
closes #106
Changing the mapping for the code fields to be able to use multi-match to search them (`cross fields` in `multi-match` requires all fields to use the same analyser).