### PR TITLE
Update CI linting & add pre-commit hooks

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,6 +17,7 @@ jobs:
           python -m pip install --upgrade ruff
           python -m pip install --upgrade black
           python -m pip install --upgrade mypy
+          python-m pip install types-requests types-psutil
       # Include `--format=github` to enable automatic inline annotations.
       - name: Run Ruff
         run: ruff check --diff --format=github .

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,6 +16,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade ruff
           python -m pip install --upgrade black
+          python -m pip install --upgrade mypy
       # Include `--format=github` to enable automatic inline annotations.
       - name: Run Ruff
         run: ruff check --diff --format=github .

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,23 +6,18 @@ jobs:
     name: Lint Code Base
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          # Full git history is needed to get a proper list
-          # of changed files within `super-linter`
-          fetch-depth: 0
-      - name: Lint Code Base
-        uses: github/super-linter@v4
-        env:
-          VALIDATE_ALL_CODEBASE: true
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # VALIDATE_ALL_CODEBASE: false # Only new or edited files
-          VALIDATE_JSCPD: false # Copy/paste detection
-          VALIDATE_GITHUB_ACTIONS: false # Due to shellcheck SC2086 issues
-          VALIDATE_MARKDOWN: false # Due to multiple headings issue
-          # VALIDATE_PYTHON_BLACK: false # Not using black
-          VALIDATE_DOCKERFILE_HADOLINT: false
-          VALIDATE_HTML: false
-          PYTHON_FLAKE8_CONFIG_FILE: .flake8
+          python-version: "3.11.2"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade ruff
+          python -m pip install --upgrade black
+      # Include `--format=github` to enable automatic inline annotations.
+      - name: Run Ruff
+        run: ruff check --diff --format=github .
+      - name: Run Black
+        uses: psf/black@stable

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,4 +23,6 @@ jobs:
       - name: Run Black
         uses: psf/black@stable
       - name: Run mypy
-        run: mypy . --no-strict-optional --ignore-missing-imports
+        run: |
+          mypy --install-types
+          mypy . --no-strict-optional --ignore-missing-imports

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Run Black
         uses: psf/black@stable
       - name: Run mypy
-        run: mypy --no-strict-optional --ignore-missing-imports
+        run: mypy . --no-strict-optional --ignore-missing-imports

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,13 +16,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade ruff
           python -m pip install --upgrade black
-          python -m pip install --upgrade mypy
-          python -m pip install types-requests types-psutil
       # Include `--format=github` to enable automatic inline annotations.
       - name: Run Ruff
         run: ruff check --diff --format=github .
       - name: Run Black
         uses: psf/black@stable
-      - name: Run mypy
-        run: |
-          mypy . --no-strict-optional --ignore-missing-imports

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -21,3 +21,5 @@ jobs:
         run: ruff check --diff --format=github .
       - name: Run Black
         uses: psf/black@stable
+      - name: Run mypy
+        run: mypy --no-strict-optional --ignore-missing-imports

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,7 @@ jobs:
           python -m pip install --upgrade ruff
           python -m pip install --upgrade black
           python -m pip install --upgrade mypy
-          python-m pip install types-requests types-psutil
+          python -m pip install types-requests types-psutil
       # Include `--format=github` to enable automatic inline annotations.
       - name: Run Ruff
         run: ruff check --diff --format=github .

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -25,5 +25,4 @@ jobs:
         uses: psf/black@stable
       - name: Run mypy
         run: |
-          mypy --install-types
           mypy . --no-strict-optional --ignore-missing-imports

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+fail_fast: true
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: debug-statements
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version
+    rev: 'v0.0.244'
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/psf/black
+    # Black version
+    rev: 23.1.0
+    hooks:
+      - id: black
+        args: [--diff, --check]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.0.0'
+    hooks:
+      - id: mypy
+        args: [--no-strict-optional, --ignore-missing-imports]
+        additional_dependencies: [tokenize-rt==3.2.0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
-        additional_dependencies: [tokenize-rt==3.2.0]
+        additional_dependencies: [tokenize-rt==3.2.0, 'types-requests']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
-        additional_dependencies: [tokenize-rt==3.2.0, 'types-requests']
+        additional_dependencies: [tokenize-rt==3.2.0, 'types-requests', 'types-psutil']

--- a/data_preprocessing/uai.py
+++ b/data_preprocessing/uai.py
@@ -3,7 +3,6 @@ import requests
 
 
 def preprocess_uai_data(data_dir):
-
     r = requests.get(
         "https://www.data.gouv.fr/fr/datasets/r/b22f04bf-64a8-495d-b8bb-d84dbc4c7983"
     )

--- a/elasticsearch/create_sirene_index.py
+++ b/elasticsearch/create_sirene_index.py
@@ -61,7 +61,6 @@ class ElasticCreateSiren:
             logging.info(f"Cluster status is functional: {self.elastic_status}")
 
     def execute(self):
-
         self.check_health()
 
         if not self.elastic_url:


### PR DESCRIPTION
Use pre-commit hooks for linting.
Update workflow actions (v3) and replace super-linter with `ruff` and `black` linters.
closes #108 