### PR TITLE
Add bilan_financier object to elasticsearch

### DIFF
--- a/DAG-insert-elk-sirene.py
+++ b/DAG-insert-elk-sirene.py
@@ -14,6 +14,7 @@ from dag_datalake_sirene.task_functions.count_nombre_etablissements_ouverts impo
 )
 from dag_datalake_sirene.task_functions.create_additional_data_tables import (
     create_agence_bio_table,
+    create_bilan_financiers_table,
     create_colter_table,
     create_rge_table,
     create_finess_table,
@@ -190,6 +191,12 @@ with DAG(
         python_callable=create_dirig_pm_table,
     )
 
+    create_bilan_financiers_table = PythonOperator(
+        task_id="create_bilan_financiers_table",
+        provide_context=True,
+        python_callable=create_bilan_financiers_table,
+    )
+
     create_convention_collective_table = PythonOperator(
         task_id="create_convention_collective_table",
         provide_context=True,
@@ -326,7 +333,8 @@ with DAG(
     create_dirig_pp_table.set_upstream(get_dirigeants_database)
     create_dirig_pm_table.set_upstream(create_dirig_pp_table)
 
-    create_convention_collective_table.set_upstream(create_dirig_pm_table)
+    create_bilan_financiers_table.set_upstream(create_dirig_pm_table)
+    create_convention_collective_table.set_upstream(create_bilan_financiers_table)
     create_rge_table.set_upstream(create_convention_collective_table)
     create_finess_table.set_upstream(create_rge_table)
     create_agence_bio_table.set_upstream(create_finess_table)

--- a/data_preprocessing/bilan_financier.py
+++ b/data_preprocessing/bilan_financier.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+
+def preprocess_bilan_financier_data(data_dir):
+    df_bilan = pd.read_csv(
+        "https://object.files.data.gouv.fr/data-pipeline-open/"
+        "prod/signaux_faibles/latest/synthese_bilans.csv",
+        dtype=str,
+    )
+    df_bilan = df_bilan.rename(columns={"chiffre_d_affaires": "ca"})
+    df_bilan["ca"] = df_bilan["ca"].astype(float)
+    df_bilan["resultat_net"] = df_bilan["resultat_net"].astype(float)
+
+    return df_bilan

--- a/elasticsearch/mapping_sirene_index.py
+++ b/elasticsearch/mapping_sirene_index.py
@@ -205,6 +205,12 @@ class ElasticsearchEluIndex(InnerDoc):
     fonction = Text()
 
 
+class BilanFinancierIndex(InnerDoc):
+    ca = Integer()
+    resultat_net = Integer()
+    date_cloture_exercice = Text()
+
+
 class ElasticsearchSireneIndex(Document):
     """
 
@@ -218,6 +224,7 @@ class ElasticsearchSireneIndex(Document):
     """
 
     activite_principale_unite_legale = Keyword()
+    bilan_financier = Nested(BilanFinancierIndex)
     categorie_entreprise = Text()
     convention_collective_renseignee = Boolean()
     colter_code = Keyword()

--- a/elasticsearch/process_unites_legales.py
+++ b/elasticsearch/process_unites_legales.py
@@ -51,6 +51,14 @@ def process_unites_legales(chunk_unites_legales_sqlite):
             else unite_legale_processed["nombre_etablissements_ouverts"]
         )
 
+        # Bilan financier
+        if unite_legale["bilan_financier"]:
+            unite_legale_processed["bilan_financier"] = json.loads(
+                unite_legale["bilan_financier"]
+            )
+        else:
+            unite_legale_processed["bilan_financier"] = {}
+
         # Activite principale
         unite_legale_processed[
             "section_activite_principale"

--- a/sqlite/queries/create_table_bilan_financier.py
+++ b/sqlite/queries/create_table_bilan_financier.py
@@ -1,0 +1,9 @@
+create_table_bilan_financier_query = """
+     CREATE TABLE IF NOT EXISTS bilan_financier
+     (
+         siren,
+         ca,
+         resultat_net,
+         date_cloture_exercice
+     )
+    """

--- a/sqlite/queries/select_fields_to_index.py
+++ b/sqlite/queries/select_fields_to_index.py
@@ -30,6 +30,19 @@ select_fields_to_index_query = """SELECT
             (SELECT json_group_array(statut_bio)
                 FROM agence_bio WHERE siren = ul.siren
             ) as statut_bio,
+            (
+                SELECT json_object(
+                    'ca', ca,
+                    'resultat_net', resultat_net,
+                    'date_cloture_exercice', date_cloture_exercice
+                )
+                FROM
+                (
+                    SELECT ca, resultat_net, date_cloture_exercice
+                    FROM bilan_financier
+                    WHERE siren = st.siren
+                )
+            ) as bilan_financier,
             (SELECT json_group_array(
                 json_object(
                     'siren', siren,

--- a/task_functions/create_additional_data_tables.py
+++ b/task_functions/create_additional_data_tables.py
@@ -3,6 +3,9 @@ from dag_datalake_sirene.data_preprocessing.collectivite_territoriale import (
     preprocess_colter_data,
     preprocess_elus_data,
 )
+from dag_datalake_sirene.data_preprocessing.bilan_financier import (
+    preprocess_bilan_financier_data,
+)
 from dag_datalake_sirene.data_preprocessing.convention_collective import (
     preprocess_convcollective_data,
 )
@@ -26,6 +29,9 @@ from dag_datalake_sirene.sqlite.queries.helpers import (
 
 from dag_datalake_sirene.sqlite.queries.create_table_agence_bio import (
     create_table_agence_bio_query,
+)
+from dag_datalake_sirene.sqlite.queries.create_table_bilan_financier import (
+    create_table_bilan_financier_query,
 )
 from dag_datalake_sirene.sqlite.queries.create_table_convention_collective import (
     create_table_convention_collective_query,
@@ -57,6 +63,17 @@ from dag_datalake_sirene.task_functions.create_and_fill_table_model import (
     create_and_fill_table_model,
     create_only_index,
 )
+
+
+def create_bilan_financiers_table():
+    return create_and_fill_table_model(
+        table_name="bilan_financier",
+        create_table_query=create_table_bilan_financier_query,
+        create_index_func=create_unique_index,
+        index_name="index_bilan_financier",
+        index_column="siren",
+        preprocess_table_data=preprocess_bilan_financier_data,
+    )
 
 
 def create_convention_collective_table():


### PR DESCRIPTION
- bilan_financier object

containing three properties : 
- ca # chiffre d'affaire
- resultat_net # résultat net
- date_cloture_exercice # date de cloture de l'exercice

I choose to only put latest `bilan` data in the index (where `date_cloture_exercice` is the highest) instead of putting an array of all `bilan_financier` from a company. It is simplier to read and to query. 

If we have a specific need on multiple `bilan_financier` for one company in API, we will evolve this format.