### PR TITLE
feat: update qualiopi source and keep valid certifications only

### DIFF
--- a/data_preprocessing/organisme_formation.py
+++ b/data_preprocessing/organisme_formation.py
@@ -22,7 +22,7 @@ def preprocess_organisme_formation_data(data_dir):
             "Bilans de compétences": "cert_bdc",
             "VAE": "cert_vae",
             "Actions de formations par apprentissage": "cert_app",
-            "Certifications": "Certifications",
+            "Certifications": "certifications",
         }
     )
     df_qualiopi = df_qualiopi[

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -13,8 +13,11 @@ ENV = Variable.get("ENV")
 def str_to_list(string):
     if string is None:
         return None
-    li = literal_eval(string)
-    return li
+    try:
+        li = literal_eval(string)
+        return li
+    except ValueError:
+        logging.info(f"////////////////Could not evaluate: {string}")
 
 
 def str_to_bool(string):


### PR DESCRIPTION
Get `qualiopi` updated data from DGE website and remove siret without valid certifications.
closes #150 
closes #149 
related to https://github.com/etalab/annuaire-entreprises-search-api/issues/227