### PR TITLE
Add command timeout to DAGs using SSHOperator

### DIFF
--- a/DAG-insert-elk-sirene.py
+++ b/DAG-insert-elk-sirene.py
@@ -303,6 +303,7 @@ with DAG(
         task_id="execute_aio_container",
         command=f"cd {PATH_AIO} "
         f"&& docker-compose -f docker-compose-aio.yml up --build -d --force",
+        cmd_timeout=60,
         dag=dag,
     )
 

--- a/DAG-restart-api.py
+++ b/DAG-restart-api.py
@@ -34,6 +34,7 @@ with DAG(
         command=f"cd {PATH_AIO} "
         f"&& docker stop aio"
         f"&& docker-compose -f docker-compose-aio.yml up --build -d --force",
+        cmd_timeout=60,
         dag=dag,
     )
 


### PR DESCRIPTION
Add a 60 seconds timeout to avoid timeouts on dev server.