### PR TITLE
fix: add specific start date otherwise it doesn't run even with schedule

### DIFF
--- a/DAG-clean-logs.py
+++ b/DAG-clean-logs.py
@@ -51,6 +51,7 @@ with DAG(
     default_args=default_args,
     description="Delete Airflow logs older than 15 days",
     schedule_interval="0 0 * * 1",  # run every Monday at midnight (UTC)
+    start_date=datetime(2023, 9, 15),
     catchup=False,  # False to ignore past runs
     max_active_runs=1,  # Allow only one execution at a time
 ) as dag:


### PR DESCRIPTION
For scheduled runs to run automatically, a specific start date has to be given to DAG.