### PR TITLE
feat: add `est_association` field to ES

### DIFF
--- a/elasticsearch/data_enrichment.py
+++ b/elasticsearch/data_enrichment.py
@@ -118,6 +118,17 @@ def is_service_public(nature_juridique_unite_legale, siren):
         return False
 
 
+# Association
+def is_association(nature_juridique_unite_legale, identifiant_association):
+    if identifiant_association:
+        return True
+    if nature_juridique_unite_legale and nature_juridique_unite_legale.startswith(
+        ("5195", "92")
+    ):
+        return True
+    return False
+
+
 # Section activité principale
 def label_section_from_activite(activite_principale_unite_legale):
     if activite_principale_unite_legale is not None:

--- a/elasticsearch/mapping_index.py
+++ b/elasticsearch/mapping_index.py
@@ -267,6 +267,7 @@ class UniteLegaleMapping(InnerDoc):
     est_entrepreneur_individuel = Boolean()
     est_entrepreneur_spectacle = Boolean()
     egapro_renseignee = Boolean()
+    est_association = Boolean()
     est_finess = Boolean()
     est_bio = Boolean()
     est_organisme_formation = Boolean()

--- a/elasticsearch/process_unites_legales.py
+++ b/elasticsearch/process_unites_legales.py
@@ -9,6 +9,7 @@ from dag_datalake_sirene.elasticsearch.data_enrichment import (
     format_nom_complet,
     format_slug,
     format_siege_unite_legale,
+    is_association,
     is_entrepreneur_individuel,
     is_service_public,
     label_section_from_activite,
@@ -118,6 +119,11 @@ def process_unites_legales(chunk_unites_legales_sqlite):
         unite_legale_processed["est_service_public"] = is_service_public(
             unite_legale["nature_juridique_unite_legale"],
             unite_legale_processed["siren"],
+        )
+
+        unite_legale_processed["est_association"] = is_association(
+            unite_legale_processed["nature_juridique_unite_legale"],
+            unite_legale_processed["identifiant_association_unite_legale"],
         )
 
         if unite_legale_processed["est_entrepreneur_individuel"]:


### PR DESCRIPTION
Use `nature juridique` as well as `identifiant association` fields to label associations.