### PR TITLE
CI: update ruff format option

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,6 +18,6 @@ jobs:
           python -m pip install --upgrade black
       # Include `--format=github` to enable automatic inline annotations.
       - name: Run Ruff
-        run: ruff check --diff --format=github .
+        run: ruff check --diff -- --format=github .
       - name: Run Black
         uses: psf/black@stable


### PR DESCRIPTION
GitHub Actions raises error when linting due to `ruff` update.