### PR TITLE
fix: update datagouv stable url to download convention collective csv

### DIFF
--- a/data_preprocessing/convention_collective.py
+++ b/data_preprocessing/convention_collective.py
@@ -4,7 +4,7 @@ import requests
 
 def preprocess_convcollective_data(data_dir):
     cc_url = (
-        "https://www.data.gouv.fr/fr/datasets/r/bfc3a658-c054-4ecc-ba4b" "-22f3f5789dc7"
+        "https://www.data.gouv.fr/fr/datasets/r/" "a22e54f7-b937-4483-9a72-aad2ea1316f1"
     )
     r = requests.get(cc_url, allow_redirects=True)
     with open(data_dir + "convcollective-download.csv", "wb") as f:


### PR DESCRIPTION
[`Liste convention collective par établissement`](https://www.data.gouv.fr/fr/datasets/liste-des-conventions-collectives-par-entreprise-siret/#/resources)  changed their file, this somehow caused the stable data.gouv link to change which in turn caused the indexation workflow to fail. This PR updates the URL.