### PR TITLE
[Mapping SIREN] unite_legale nested doc is also included in root

### DIFF
--- a/elasticsearch/mapping_index.py
+++ b/elasticsearch/mapping_index.py
@@ -303,7 +303,7 @@ class StructureMapping(Document):
     identifiant = Keyword()
     nom_complet = Text(analyzer=annuaire_analyzer, fields={"keyword": Keyword()})
     adresse = Text(analyzer=annuaire_analyzer)
-    unite_legale = Object(UniteLegaleMapping)
+    unite_legale = Object(UniteLegaleMapping, include_in_root=true)
 
     class Index:
         name = f"siren-{NEXT_COLOR}"


### PR DESCRIPTION
Les documents d'unité légales restent "nested" mais sont également inclus dans le document root.

Cela implique que ces champs sont indexés deux fois : au niveau des documents nested et au niveau du document root, donc la taille de l'index va augmenter.

Il sera à présent possible de faire des recherches par SIRET sans passer par une query nested.
Ca va permettre d'éviter la jointure entre le doc nested et le doc parent lors des recherches.
Le gain est mineur (~0.5ms/recherche de SIRET) mais il est devient significatif lorsque l'on a des pics de 100 recherches par SIRET par seconde.

Cette merge request devra être déployé, et les documents réindexés, avant de déployer la merge request côté API qui va changer le fonctionnement des recherches par SIRET.

La merge request API est celle-ci : https://github.com/etalab/annuaire-entreprises-search-api/pull/308

:warning: ce code n'a pas encore pu être testé localement