### PR TITLE
[DATA-PIPELINES][RNE]feat: run dag daily at midnight

### DIFF
--- a/data_pipelines/rne/flux/DAG.py
+++ b/data_pipelines/rne/flux/DAG.py
@@ -23,7 +23,7 @@ with DAG(
     dag_id="get_flux_rne",
     default_args=default_args,
     start_date=datetime(2023, 10, 18),
-    schedule_interval="0 2 * * *",  # Run every day at 2 AM
+    schedule_interval="0 0 * * *",  # Run every day at midnight
     catchup=False,
     max_active_runs=1,
     dagrun_timeout=timedelta(minutes=(60 * 100)),


### PR DESCRIPTION
Running DAG at midnight instead of at 2am allows for an extra 2 hours of processing while RNE API has low traffic.