### PR TITLE
[DATA][ESS]feat: use new ESS France dataset to build `est_ess` field

### DIFF
--- a/DAG-insert-elk-sirene.py
+++ b/DAG-insert-elk-sirene.py
@@ -15,6 +15,7 @@ from dag_datalake_sirene.task_functions.create_additional_data_tables import (
     create_agence_bio_table,
     create_bilan_financiers_table,
     create_colter_table,
+    create_ess_table,
     create_rge_table,
     create_finess_table,
     create_egapro_table,
@@ -219,6 +220,12 @@ with DAG(
         python_callable=create_convention_collective_table,
     )
 
+    create_ess_table = PythonOperator(
+        task_id="create_ess_table",
+        provide_context=True,
+        python_callable=create_ess_table,
+    )
+
     create_rge_table = PythonOperator(
         task_id="create_rge_table",
         provide_context=True,
@@ -376,7 +383,8 @@ with DAG(
 
     create_bilan_financiers_table.set_upstream(create_dirig_pm_table)
     create_convention_collective_table.set_upstream(create_bilan_financiers_table)
-    create_rge_table.set_upstream(create_convention_collective_table)
+    create_ess_table.set_upstream(create_convention_collective_table)
+    create_rge_table.set_upstream(create_ess_table)
     create_finess_table.set_upstream(create_rge_table)
     create_agence_bio_table.set_upstream(create_finess_table)
     create_organisme_formation_table.set_upstream(create_agence_bio_table)

--- a/config.py
+++ b/config.py
@@ -125,3 +125,6 @@ URL_UAI = (
     "prod/uai/latest/annuaire_uai.csv"
 )
 URL_UNITE_LEGALE = "https://files.data.gouv.fr/insee-sirene/StockUniteLegale_utf8.zip"
+URL_ESS_FRANCE = (
+    "https://www.data.gouv.fr/fr/datasets/r/57bc99ca-0432-4b46-8fcc-e76a35c9efaf"
+)

--- a/data_preprocessing/ess_france.py
+++ b/data_preprocessing/ess_france.py
@@ -6,6 +6,6 @@ def preprocess_ess_france_data(data_dir):
     df_ess = pd.read_csv(URL_ESS_FRANCE, dtype=str)
     df_ess["SIREN"] = df_ess["SIREN"].str.zfill(9)
     df_ess.rename(columns={"SIREN": "siren"}, inplace=True)
-    df_ess["est_ess"] = True
-    df_ess = df_ess[["siren", "est_ess"]]
+    df_ess["est_ess_france"] = True
+    df_ess = df_ess[["siren", "est_ess_france"]]
     return df_ess

--- a/data_preprocessing/ess_france.py
+++ b/data_preprocessing/ess_france.py
@@ -7,4 +7,5 @@ def preprocess_ess_france_data(data_dir):
     df_ess["SIREN"] = df_ess["SIREN"].str.zfill(9)
     df_ess.rename(columns={"SIREN": "siren"}, inplace=True)
     df_ess["est_ess"] = True
+    df_ess = df_ess[["siren", "est_ess"]]
     return df_ess

--- a/data_preprocessing/ess_france.py
+++ b/data_preprocessing/ess_france.py
@@ -1,0 +1,10 @@
+import pandas as pd
+from dag_datalake_sirene.config import URL_ESS_FRANCE
+
+
+def preprocess_ess_france_data(data_dir):
+    df_ess = pd.read_csv(URL_ESS_FRANCE, dtype=str)
+    df_ess["SIREN"] = df_ess["SIREN"].str.zfill(9)
+    df_ess.rename(columns={"SIREN": "siren"}, inplace=True)
+    df_ess["est_ess"] = True
+    return df_ess

--- a/elasticsearch/data_enrichment.py
+++ b/elasticsearch/data_enrichment.py
@@ -105,6 +105,12 @@ def is_entrepreneur_individuel(nature_juridique_unite_legale):
         return False
 
 
+# ESS
+def is_ess(est_ess_france, ess_insee):
+    est_ess_insee = ess_insee == "O" if ess_insee is not None else False
+    return est_ess_france or est_ess_insee
+
+
 # Service public
 def is_service_public(nature_juridique_unite_legale, siren):
     if (

--- a/elasticsearch/mapping_index.py
+++ b/elasticsearch/mapping_index.py
@@ -275,6 +275,7 @@ class UniteLegaleMapping(InnerDoc):
     est_association = Boolean()
     est_finess = Boolean()
     est_bio = Boolean()
+    est_ess = Boolean()
     est_organisme_formation = Boolean()
     liste_id_organisme_formation = Text()
     est_qualiopi = Boolean()

--- a/elasticsearch/process_unites_legales.py
+++ b/elasticsearch/process_unites_legales.py
@@ -154,8 +154,7 @@ def process_unites_legales(chunk_unites_legales_sqlite):
 
         # ESS
 
-        unite_legale_processed["est_ess"] = is_ess
-        (
+        unite_legale_processed["est_ess"] = is_ess(
             sqlite_str_to_bool(unite_legale["est_ess_france"]),
             unite_legale["economie_sociale_solidaire_unite_legale"],
         )

--- a/elasticsearch/process_unites_legales.py
+++ b/elasticsearch/process_unites_legales.py
@@ -152,7 +152,11 @@ def process_unites_legales(chunk_unites_legales_sqlite):
         )
 
         # ESS
-        unite_legale_processed["est_ess"] = sqlite_str_to_bool(unite_legale["est_ess"])
+        unite_legale_processed["est_ess"] = (
+            sqlite_str_to_bool(unite_legale["est_ess_france"])
+            | unite_legale["economie_sociale_solidaire_unite_legale"]
+            == "O"
+        )
 
         # Egapro
         unite_legale_processed["egapro_renseignee"] = sqlite_str_to_bool(

--- a/elasticsearch/process_unites_legales.py
+++ b/elasticsearch/process_unites_legales.py
@@ -11,6 +11,7 @@ from dag_datalake_sirene.elasticsearch.data_enrichment import (
     format_siege_unite_legale,
     is_association,
     is_entrepreneur_individuel,
+    is_ess,
     is_service_public,
     label_section_from_activite,
 )
@@ -152,10 +153,11 @@ def process_unites_legales(chunk_unites_legales_sqlite):
         )
 
         # ESS
-        unite_legale_processed["est_ess"] = (
-            sqlite_str_to_bool(unite_legale["est_ess_france"])
-            | unite_legale["economie_sociale_solidaire_unite_legale"]
-            == "O"
+
+        unite_legale_processed["est_ess"] = is_ess
+        (
+            sqlite_str_to_bool(unite_legale["est_ess_france"]),
+            unite_legale["economie_sociale_solidaire_unite_legale"],
         )
 
         # Egapro

--- a/elasticsearch/process_unites_legales.py
+++ b/elasticsearch/process_unites_legales.py
@@ -151,6 +151,9 @@ def process_unites_legales(chunk_unites_legales_sqlite):
             unite_legale["est_entrepreneur_spectacle"]
         )
 
+        # ESS
+        unite_legale_processed["est_ess"] = sqlite_str_to_bool(unite_legale["est_ess"])
+
         # Egapro
         unite_legale_processed["egapro_renseignee"] = sqlite_str_to_bool(
             unite_legale["egapro_renseignee"]

--- a/sqlite/queries/create_table_ess_france.py
+++ b/sqlite/queries/create_table_ess_france.py
@@ -1,0 +1,7 @@
+create_table_ess_query = """
+     CREATE TABLE IF NOT EXISTS ess_france
+     (
+         siren,
+         est_ess
+     )
+    """

--- a/sqlite/queries/create_table_ess_france.py
+++ b/sqlite/queries/create_table_ess_france.py
@@ -2,6 +2,6 @@ create_table_ess_query = """
      CREATE TABLE IF NOT EXISTS ess_france
      (
          siren,
-         est_ess
+         est_ess_france
      )
     """

--- a/sqlite/queries/select_fields_to_index.py
+++ b/sqlite/queries/select_fields_to_index.py
@@ -330,8 +330,8 @@ select_fields_to_index_query = """SELECT
             colter_code_insee,
             (SELECT colter_code FROM colter WHERE siren = ul.siren) as colter_code,
             (SELECT colter_niveau FROM colter WHERE siren = ul.siren) as colter_niveau,
-            (SELECT est_ess FROM ess_france WHERE siren = ul.siren) as
-            est_ess,
+            (SELECT est_ess_france FROM ess_france WHERE siren = ul.siren) as
+            est_ess_france,
             (SELECT json_group_array(
                 json_object(
                     'siren', siren,

--- a/sqlite/queries/select_fields_to_index.py
+++ b/sqlite/queries/select_fields_to_index.py
@@ -330,6 +330,8 @@ select_fields_to_index_query = """SELECT
             colter_code_insee,
             (SELECT colter_code FROM colter WHERE siren = ul.siren) as colter_code,
             (SELECT colter_niveau FROM colter WHERE siren = ul.siren) as colter_niveau,
+            (SELECT est_ess FROM ess_france WHERE siren = ul.siren) as
+            est_ess,
             (SELECT json_group_array(
                 json_object(
                     'siren', siren,

--- a/task_functions/create_additional_data_tables.py
+++ b/task_functions/create_additional_data_tables.py
@@ -15,6 +15,9 @@ from dag_datalake_sirene.data_preprocessing.egapro import (
 from dag_datalake_sirene.data_preprocessing.entrepreneur_spectacle import (
     preprocess_spectacle_data,
 )
+from dag_datalake_sirene.data_preprocessing.ess_france import (
+    preprocess_ess_france_data,
+)
 from dag_datalake_sirene.data_preprocessing.finess import preprocess_finess_data
 from dag_datalake_sirene.data_preprocessing.organisme_formation import (
     preprocess_organisme_formation_data,
@@ -39,6 +42,9 @@ from dag_datalake_sirene.sqlite.queries.create_table_egapro import (
     create_table_egapro_query,
 )
 from dag_datalake_sirene.sqlite.queries.create_table_rge import create_table_rge_query
+from dag_datalake_sirene.sqlite.queries.create_table_ess_france import (
+    create_table_ess_query,
+)
 from dag_datalake_sirene.sqlite.queries.create_table_finess import (
     create_table_finess_query,
 )
@@ -183,4 +189,15 @@ def create_elu_table():
         index_name="index_elus",
         index_column="siren",
         preprocess_table_data=preprocess_elus_data,
+    )
+
+
+def create_ess_table():
+    return create_and_fill_table_model(
+        table_name="ess",
+        create_table_query=create_table_ess_query,
+        create_index_func=create_index,
+        index_name="index_ess",
+        index_column="siren",
+        preprocess_table_data=preprocess_ess_france_data,
     )

--- a/task_functions/create_additional_data_tables.py
+++ b/task_functions/create_additional_data_tables.py
@@ -194,7 +194,7 @@ def create_elu_table():
 
 def create_ess_table():
     return create_and_fill_table_model(
-        table_name="ess",
+        table_name="ess_france",
         create_table_query=create_table_ess_query,
         create_index_func=create_index,
         index_name="index_ess",


### PR DESCRIPTION
closes #215

The `est_ess` field in the index was initially constructed using data from the `economie_sociale_solidaire_unite_legale` field in the SIRENE dataset. However, the updated ESS France dataset will now serve as an additional source for building this particular field.
Henceforth, `est_ess = est_ess_france || economie_sociale_solidaire_unite_legale`.