### PR TITLE
[METADATA]feat: create json file with `conventions collectives` metadata

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,6 +24,8 @@ RNE_STOCK_ZIP_FILE_PATH = f"{RNE_STOCK_TMP_FOLDER}stock_rne.zip"
 RNE_STOCK_EXTRACTED_FILES_PATH = f"{RNE_STOCK_TMP_FOLDER}extracted/"
 RNE_STOCK_DATADIR = f"{RNE_STOCK_TMP_FOLDER}data"
 RNE_DAG_FOLDER = "dag_datalake_sirene/data_pipelines/"
+METADATA_CC_TMP_FOLDER = f"{AIRFLOW_DAG_TMP}metadata/cc/"
+METADATA_CC_MINIO_PATH = "metadata/cc/"
 
 # Notification
 TCHAP_ANNUAIRE_WEBHOOK = Variable.get("TCHAP_ANNUAIRE_WEBHOOK", "")
@@ -61,6 +63,7 @@ ELASTIC_USER = Variable.get("ELASTIC_USER")
 ELASTIC_BULK_SIZE = 1500
 ELASTIC_SHARDS = 1
 ELASTIC_REPLICAS = 0
+
 
 # Datasets
 URL_AGENCE_BIO = (
@@ -127,4 +130,11 @@ URL_UAI = (
 URL_UNITE_LEGALE = "https://files.data.gouv.fr/insee-sirene/StockUniteLegale_utf8.zip"
 URL_ESS_FRANCE = (
     "https://www.data.gouv.fr/fr/datasets/r/57bc99ca-0432-4b46-8fcc-e76a35c9efaf"
+)
+URL_CC_DARES = (
+    "https://travail-emploi.gouv.fr/IMG/xlsx/"
+    "dares_donnes_identifiant_convention_collective_novembre23.xlsx"
+)
+URL_CC_KALI = (
+    "https://www.data.gouv.fr/fr/datasets/r/02b67492-5243-44e8-8dd1-0cb3f90f35ff"
 )

--- a/data_pipelines/metadata/cc/DAG-get-metadata-cc.py
+++ b/data_pipelines/metadata/cc/DAG-get-metadata-cc.py
@@ -1,0 +1,56 @@
+from airflow.models import DAG
+from datetime import timedelta, datetime
+from airflow.operators.bash import BashOperator
+from airflow.operators.python import PythonOperator
+from dag_datalake_sirene.config import EMAIL_LIST, METADATA_CC_TMP_FOLDER
+from dag_datalake_sirene.data_pipelines.metadata.cc.task_functions import (
+    create_metadata_concollective_json,
+    upload_json_file_to_minio,
+    send_notification_failure_tchap,
+    send_notification_success_tchap,
+)
+
+default_args = {
+    "depends_on_past": False,
+    "email": EMAIL_LIST,
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+with DAG(
+    dag_id="get_metadata_cc",
+    default_args=default_args,
+    start_date=datetime(2023, 11, 23),
+    schedule_interval="0 11 * * *",  # Run every day at 11 am
+    catchup=False,
+    max_active_runs=1,
+    dagrun_timeout=timedelta(minutes=(60 * 100)),
+    on_failure_callback=send_notification_failure_tchap,
+    tags=["api", "metadata", "cc"],
+    params={},
+) as dag:
+    clean_previous_outputs = BashOperator(
+        task_id="clean_previous_outputs",
+        bash_command=f"rm -rf {METADATA_CC_TMP_FOLDER} "
+        f"&& mkdir -p {METADATA_CC_TMP_FOLDER}",
+    )
+
+    create_metadata_concollective_json = PythonOperator(
+        task_id="create_metadata_cc_json",
+        python_callable=create_metadata_concollective_json,
+    )
+
+    upload_json_to_minio = PythonOperator(
+        task_id="upload_json_to_minio", python_callable=upload_json_file_to_minio
+    )
+
+    send_notification_success_tchap = PythonOperator(
+        task_id="send_notification_success_tchap",
+        python_callable=send_notification_success_tchap,
+    )
+
+    create_metadata_concollective_json.set_upstream(clean_previous_outputs)
+    upload_json_to_minio.set_upstream(create_metadata_concollective_json)
+    send_notification_success_tchap.set_upstream(upload_json_to_minio)

--- a/data_pipelines/metadata/cc/task_functions.py
+++ b/data_pipelines/metadata/cc/task_functions.py
@@ -1,0 +1,102 @@
+import pandas as pd
+import requests
+import json
+from dag_datalake_sirene.utils.tchap import send_message
+from dag_datalake_sirene.utils.minio_helpers import (
+    send_files,
+)
+from dag_datalake_sirene.config import (
+    URL_CC_DARES,
+    URL_CC_KALI,
+    METADATA_CC_MINIO_PATH,
+    METADATA_CC_TMP_FOLDER,
+    MINIO_URL,
+    MINIO_BUCKET,
+    MINIO_USER,
+    MINIO_PASSWORD,
+)
+
+
+def create_metadata_concollective_json():
+    # Get Draes list
+    r = requests.get(URL_CC_DARES, allow_redirects=True)
+    with open(METADATA_CC_TMP_FOLDER + "dares-download.xlsx", "wb") as f:
+        for chunk in r.iter_content(1024):
+            f.write(chunk)
+    df_dares = pd.read_excel(
+        METADATA_CC_TMP_FOLDER + "dares-download.xlsx",
+        dtype=str,
+        header=0,
+        skiprows=3,
+        engine="openpyxl",
+    )
+    # Get Kali list
+    r = requests.get(URL_CC_KALI, allow_redirects=True)
+    with open(METADATA_CC_TMP_FOLDER + "kali-download.xlsx", "wb") as f:
+        for chunk in r.iter_content(1024):
+            f.write(chunk)
+    df_kali = pd.read_excel(
+        METADATA_CC_TMP_FOLDER + "kali-download.xlsx",
+        header=0,
+        skiprows=3,
+        dtype=str,
+        engine="openpyxl",
+    )
+    # Sort by date
+    df_kali = df_kali.sort_values(by="DEBUT", ascending=False)
+    df_kali = df_kali.drop_duplicates(subset="ID", keep="first")
+    df_kali = df_kali.drop(columns=["Unnamed: 0"], errors="ignore")
+
+    merged_df = pd.merge(df_dares, df_kali, left_on="IDCC", right_on="IDCC", how="left")
+    merged_df.columns = merged_df.columns.str.lower()
+    merged_df = merged_df.drop(columns=["titre"], errors="ignore")
+    merged_df = merged_df.where(pd.notna(merged_df), None)
+    merged_df.rename(columns={"id": "id_kali"}, inplace=True)
+    merged_df.set_index("idcc", inplace=True)
+
+    columns_to_keep = [
+        "titre de la convention",
+        "id_kali",
+        "cc_ti",
+        "nature",
+        "etat",
+        "debut",
+        "fin",
+        "url",
+    ]
+    merged_df = merged_df[columns_to_keep]
+
+    metadata_dict = merged_df.to_dict(orient="index")
+    metadata_json = {str(key): value for key, value in metadata_dict.items()}
+
+    with open(METADATA_CC_TMP_FOLDER + "metadata-cc-kali.json", "w") as json_file:
+        json.dump(metadata_json, json_file)
+
+
+def upload_json_file_to_minio():
+    send_files(
+        MINIO_URL=MINIO_URL,
+        MINIO_BUCKET=MINIO_BUCKET,
+        MINIO_USER=MINIO_USER,
+        MINIO_PASSWORD=MINIO_PASSWORD,
+        list_files=[
+            {
+                "source_path": METADATA_CC_TMP_FOLDER,
+                "source_name": "metadata-cc-kali.json",
+                "dest_path": METADATA_CC_MINIO_PATH,
+                "dest_name": "cc_kali.json",
+            }
+        ],
+    )
+
+
+def send_notification_success_tchap():
+    send_message(
+        f"\U0001F7E2 Données :"
+        f"\nMetadata Conventions Collectives mise à jour sur Minio "
+        f"- Bucket {MINIO_BUCKET}."
+    )
+
+
+def send_notification_failure_tchap(context):
+    send_message("\U0001F534 Données :" "\nFail DAG Metadata CC!!!!")


### PR DESCRIPTION
closes https://github.com/etalab/annuaire-entreprises-search-infra/issues/218

Here's a summary of the changes introduced by the PR:

* Retrieves a list of "conventions collectives" from Dares, as detailed in the linked issue for further clarification.
* Retrieves the Kali list from the data.gouv source.
* Combines and merges these lists, giving priority to the Dares file as the primary source.
* The primary use of the combined list is in the Dares dataset, supplemented with additional information from the Kali dataset.
* The resulting JSON file is saved to MinIO and is utilized by the API metadata endpoint.

In essence, this PR enhances the Dares dataset by incorporating information from the Kali dataset, creating a comprehensive list that serves as a valuable resource for the API metadata endpoint.