### PR TITLE
[DATA-PIPELINES–[RNE]feat: increase timeout to 30 days for DAG RNE flux

### DIFF
--- a/data_pipelines/rne/flux/DAG.py
+++ b/data_pipelines/rne/flux/DAG.py
@@ -26,7 +26,7 @@ with DAG(
     schedule_interval="0 0 * * *",  # Run every day at midnight
     catchup=False,
     max_active_runs=1,
-    dagrun_timeout=timedelta(minutes=(60 * 100)),
+    dagrun_timeout=timedelta(days=30),
     on_failure_callback=send_notification_failure_tchap,
     tags=["api", "rne", "flux"],
     params={},


### PR DESCRIPTION
The Flux DAG has been in execution for over 72 hours on the file dated October 31, 2023, and its size has surpassed 30 Gb. Unfortunately, the current timeout of 100 hours is proving insufficient, and there is no clear indication of when the process will conclude. Hopefully a 30 days timeout will be enough, though I doubt it 🤷‍♀️ 