### PR TITLE
[INDEX MAPPING]feat: add etabs number to doc id in elasticsearch

### DIFF
--- a/elasticsearch/indexing_unite_legale.py
+++ b/elasticsearch/indexing_unite_legale.py
@@ -42,7 +42,7 @@ def doc_unite_legale_generator(data):
         # as is
         else:
             yield StructureMapping(
-                meta={"id": "document['identifiant']-100"}, **document
+                meta={"id": f"{document['identifiant']}-100"}, **document
             ).to_dict(include_meta=True)
 
 

--- a/elasticsearch/indexing_unite_legale.py
+++ b/elasticsearch/indexing_unite_legale.py
@@ -42,7 +42,7 @@ def doc_unite_legale_generator(data):
         # as is
         else:
             yield StructureMapping(
-                meta={"id": document["identifiant"]}, **document
+                meta={"id": "document['identifiant']-100"}, **document
             ).to_dict(include_meta=True)
 
 


### PR DESCRIPTION
To enable the use of the `page_etablissements` parameter for all Sirens, including those with less than 100 establishments, a numerical extension has been incorporated into the document ID within Elasticsearch`siren-100`. This extension facilitates the application of the same logic in the API for filtering and querying documents by Siren, ensuring comprehensive coverage for Sirens with varying numbers of establishments.
Related to https://github.com/etalab/annuaire-entreprises-search-api/pull/317 and https://github.com/etalab/annuaire-entreprises-search-api/pull/320