### PR TITLE
[DATA-PIPELINES][RNE]fix: extract `dirigeants` for all types of `entreprise`

### DIFF
--- a/data_pipelines/rne/database/process_rne.py
+++ b/data_pipelines/rne/database/process_rne.py
@@ -251,10 +251,7 @@ def extract_dirigeants_data(entity, file_type="flux"):
     list_dirigeants_pp = []
     list_dirigeants_pm = []
 
-    if file_type == "flux":
-        company = entity.get("company", {})
-    elif file_type == "stock":
-        company = entity
+    company = entity.get("company", {}) if file_type == "flux" else entity
 
     siren, date_maj, dirigeants = get_dirigeants_from_company(company)
 

--- a/data_pipelines/rne/database/process_rne.py
+++ b/data_pipelines/rne/database/process_rne.py
@@ -123,11 +123,6 @@ def find_and_delete_same_siren(cursor, siren, file_path):
     count_already_existing_siren = cursor.fetchone()[0]
     # If existing rows are found, delete them as they are outdated
     if count_already_existing_siren is not None:
-        if siren == "980471080":
-            logging.info(
-                f"%%%%%%%%%%%%%%already exists: {count_already_existing_siren}:"
-                f"file path: {file_path}"
-            )
         cursor.execute(
             "DELETE FROM dirigeants_pp WHERE siren = ? AND file_name != ?",
             (siren, file_path),

--- a/data_pipelines/rne/database/process_rne.py
+++ b/data_pipelines/rne/database/process_rne.py
@@ -219,11 +219,7 @@ def get_tables_count(db_path):
     return count_pp, count_pm
 
 
-def get_dirigeants_from_entity(entity, type_doc="flux"):
-    if type_doc == "flux":
-        company = entity.get("company", {})
-    elif type_doc == "stock":
-        company = entity
+def get_dirigeants_from_company(company):
     siren = company.get("siren")
     date_maj = company.get("updatedAt")
 
@@ -255,7 +251,12 @@ def extract_dirigeants_data(entity, file_type="flux"):
     list_dirigeants_pp = []
     list_dirigeants_pm = []
 
-    siren, date_maj, dirigeants = get_dirigeants_from_entity(entity, file_type)
+    if file_type == "flux":
+        company = entity.get("company", {})
+    elif file_type == "stock":
+        company = entity
+
+    siren, date_maj, dirigeants = get_dirigeants_from_company(company)
 
     for dirigeant in dirigeants:
         type_of_personne = dirigeant.get("typeDePersonne", None)

--- a/data_pipelines/rne/database/process_rne.py
+++ b/data_pipelines/rne/database/process_rne.py
@@ -195,7 +195,6 @@ def insert_dirigeants_into_db(
                 file_path,
             ),
         )
-
     cursor.execute("SELECT COUNT(*) FROM dirigeants_pp")
     count_pp = cursor.fetchone()[0]
 
@@ -308,7 +307,9 @@ def extract_dirigeants_data(entity, file_type="flux"):
                 "code_insee_commune": adresse_entreprise.get("codeInseeCommune", None),
                 "voie": adresse_entreprise.get("voie", None),
             }
+
             list_dirigeants_pm.append(dirigeant_pm)
+
         elif is_personne_physique:
             entrepreneur = dirigeant.get("entrepreneur", {}).get(
                 "descriptionPersonne", {}
@@ -339,6 +340,7 @@ def extract_dirigeants_data(entity, file_type="flux"):
             # Check if dirigeant_pp["prenoms"] is a list
             if isinstance(dirigeant_pp["prenoms"], list):
                 dirigeant_pp["prenoms"] = " ".join(dirigeant_pp["prenoms"])
+
             list_dirigeants_pp.append(dirigeant_pp)
 
     return list_dirigeants_pp, list_dirigeants_pm

--- a/data_pipelines/rne/database/rne_model.py
+++ b/data_pipelines/rne/database/rne_model.py
@@ -1,0 +1,140 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class Adresse(BaseModel):
+    pays: str | None = None
+    codePays: str | None = None
+    commune: str | None = None
+    codePostal: str | None = None
+    codeInseeCommune: str | None = None
+    voie: str | None = None
+
+
+class DescriptionPersonne(BaseModel):
+    dateDeNaissance: str | None = None
+    nom: str | None = None
+    nomUsage: str | None = None
+    prenoms: list[str] | None = None
+    genre: str | None = None
+    titre: str | None = None
+    role: str | None = None
+    nationalite: str | None = None
+    situationMatrimoniale: str | None = None
+
+
+class PouvoirIndividu(BaseModel):
+    descriptionPersonne: DescriptionPersonne | None = DescriptionPersonne()
+    adresseDomicile: Adresse | None = Adresse()
+
+
+class PouvoirEntreprise(BaseModel):
+    pays: str | None = None
+    siren: str | None = None
+    denomination: str | None = None
+    role: str | None = None
+    formeJuridique: str | None = None
+    autreIdentifiantEtranger: str | None = None
+    nicSiege: str | None = None
+    nomCommercial: str | None = None
+
+
+class Entrepreneur(BaseModel):
+    descriptionPersonne: DescriptionPersonne | None = DescriptionPersonne()
+    adresseDomicile: Adresse | None = Adresse()
+
+
+class Pouvoir(BaseModel):
+    typeDePersonne: str | None = None
+    individu: PouvoirIndividu | None = PouvoirIndividu()
+    entreprise: PouvoirEntreprise | None = PouvoirEntreprise()
+    adresseEntreprise: Adresse | None = Adresse()
+
+
+class Composition(BaseModel):
+    pouvoirs: list[Pouvoir] | None = None
+
+
+class Identite(BaseModel):
+    entreprise: dict | None = None
+    entrepreneur: Entrepreneur | None = Entrepreneur()
+
+
+class Exploitation(BaseModel):
+    identite: dict | None = None
+    composition: Composition | None = None
+
+    @property
+    def dirigeants(self):
+        return self.composition.pouvoirs if self.composition else []
+
+
+class PersonneMorale(BaseModel):
+    identite: dict | None = None
+    composition: Composition | None = None
+
+    @property
+    def dirigeants(self):
+        return self.composition.pouvoirs if self.composition else []
+
+
+class PersonnePhysique(BaseModel):
+    identite: Identite | None = None
+    composition: Composition | None = None
+
+    @property
+    def dirigeants(self):
+        return [self.identite.entrepreneur if self.identite else None]
+
+
+class Content(BaseModel):
+    personnePhysique: PersonnePhysique | None = None
+    personneMorale: PersonneMorale | None = None
+    exploitation: Exploitation | None = None
+
+
+class Formality(BaseModel):
+    siren: str
+    content: Content
+    typePersonne: str | None = None
+    formeJuridique: str | None = None
+    created: datetime | None = None
+    updated: datetime | None = None
+
+
+class RNECompany(BaseModel):
+    updatedAt: datetime
+    formality: Formality
+    siren: str
+
+    @property
+    def dirigeants(self):
+        if self.is_personne_morale():
+            return (
+                self.formality.content.personneMorale.dirigeants
+                if hasattr(self.formality.content.personneMorale, "dirigeants")
+                else []
+            )
+        elif self.is_exploitation():
+            return (
+                self.formality.content.exploitation.dirigeants
+                if hasattr(self.formality.content.exploitation, "dirigeants")
+                else []
+            )
+        elif self.is_personne_physique():
+            return (
+                self.formality.content.personnePhysique.dirigeants
+                if hasattr(self.formality.content.personnePhysique, "dirigeants")
+                else []
+            )
+        else:
+            return []
+
+    def is_personne_morale(self) -> bool:
+        return isinstance(self.formality.content.personneMorale, PersonneMorale)
+
+    def is_exploitation(self) -> bool:
+        return isinstance(self.formality.content.exploitation, Exploitation)
+
+    def is_personne_physique(self) -> bool:
+        return isinstance(self.formality.content.personnePhysique, PersonnePhysique)

--- a/data_pipelines/rne/database/rne_model.py
+++ b/data_pipelines/rne/database/rne_model.py
@@ -110,23 +110,11 @@ class RNECompany(BaseModel):
     @property
     def dirigeants(self):
         if self.is_personne_morale():
-            return (
-                self.formality.content.personneMorale.dirigeants
-                if hasattr(self.formality.content.personneMorale, "dirigeants")
-                else []
-            )
+            return self.formality.content.personneMorale.dirigeants
         elif self.is_exploitation():
-            return (
-                self.formality.content.exploitation.dirigeants
-                if hasattr(self.formality.content.exploitation, "dirigeants")
-                else []
-            )
+            return self.formality.content.exploitation.dirigeants
         elif self.is_personne_physique():
-            return (
-                self.formality.content.personnePhysique.dirigeants
-                if hasattr(self.formality.content.personnePhysique, "dirigeants")
-                else []
-            )
+            return self.formality.content.personnePhysique.dirigeants
         else:
             return []
 

--- a/data_pipelines/rne/database/task_functions.py
+++ b/data_pipelines/rne/database/task_functions.py
@@ -247,7 +247,7 @@ def process_flux_json_files(**kwargs):
     kwargs["ti"].xcom_push(key="last_date_processed", value=last_date_processed)
 
 
-def check_db_count(ti, min_pp_table_count=12000000, min_pm_table_count=1000000):
+def check_db_count(ti, min_pp_table_count=11000000, min_pm_table_count=1000000):
     try:
         rne_db_path = ti.xcom_pull(key="rne_db_path", task_ids="create_db")
         count_pp, count_pm = get_tables_count(rne_db_path)


### PR DESCRIPTION
Previously, there was ambiguity regarding the location of the `dirigeants` data returned by the RNE API. Typically, it was found within the `pouvoirs` block under the `exploitation` block. However, it has been discovered that for other types of `entreprises`, the `dirigeants` data may be included in different blocks.

Previously, our extraction process focused solely on retrieving the `pouvoirs` block for the `exploitation` type. In this pull request, we are expanding the extraction to include the `pouvoirs` block for the `personneMorale` type and the `identite` block for type `personnePhysique`.

This PR introduces a `RNECompany` data model designed to streamline the extraction of `dirigeant` data from JSON objects.

depends on https://github.com/etalab/annuaire-entreprises-search-infra/pull/228