### PR TITLE
[BUG][MAINTENANCE] fix: DAG to clean Airflow logs

### DIFF
--- a/maintenance/DAG_clean_logs.py
+++ b/maintenance/DAG_clean_logs.py
@@ -50,7 +50,7 @@ with DAG(
     "delete_airflow_logs",
     default_args=default_args,
     description="Delete Airflow logs older than 15 days",
-    schedule_interval="0 0 * * 1",  # run every Monday at midnight (UTC)
+    schedule_interval="0 16 * * 1",  # run every Monday at 4:00 PM (UTC)
     dagrun_timeout=timedelta(minutes=30),
     start_date=datetime(2023, 9, 15),
     catchup=False,  # False to ignore past runs

--- a/maintenance/DAG_clean_logs.py
+++ b/maintenance/DAG_clean_logs.py
@@ -14,7 +14,6 @@ from dag_datalake_sirene.config import (
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": datetime.now() - timedelta(days=1),  # Set the start_date to yesterday
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
 }
@@ -52,7 +51,7 @@ with DAG(
     description="Delete Airflow logs older than 15 days",
     schedule_interval="0 16 * * 1",  # run every Monday at 4:00 PM (UTC)
     dagrun_timeout=timedelta(minutes=30),
-    start_date=datetime(2023, 9, 15),
+    start_date=datetime(2023, 12, 28),
     catchup=False,  # False to ignore past runs
     max_active_runs=1,  # Allow only one execution at a time
 ) as dag:


### PR DESCRIPTION
closes #231 

The [problem](https://stackoverflow.com/questions/73652663/airflow-dag-run-marked-as-success-although-the-tasks-didnt-run#:~:text=If%20you%20see%20dag%20runs,dates.) arises from the conflicting definitions of the `start_date`, which is set in both the `default_args` dictionary and the `DAG()` object with different values. Although DAG runs were marked as successful, the tasks failed to execute automatically unless manually triggered.

This pull request (PR) addresses the issue by removing the dynamic start date from the `default_args` dictionary and updating the `start_date` and `schedule_interval` parameters in the `DAG()` object. These changes aim to prevent the unintentional deletion of logs while other pipelines are executing.

<img width="313" alt="Screenshot 2023-12-28 at 16 41 14" src="https://github.com/etalab/annuaire-entreprises-search-infra/assets/48837850/44fefdb8-f8c6-4904-88f9-890f7a8ca209">
