### PR TITLE
[REFACTOR]feat: add MinIOClient class

### DIFF
--- a/helpers/update_color_file.py
+++ b/helpers/update_color_file.py
@@ -1,14 +1,7 @@
 import json
 import logging
 
-from minio import Minio
-from dag_datalake_sirene.config import (
-    AIRFLOW_ENV,
-    MINIO_URL,
-    MINIO_BUCKET,
-    MINIO_USER,
-    MINIO_PASSWORD,
-)
+from dag_datalake_sirene.helpers.minio_helpers import minio_client
 
 
 def update_color_file(**kwargs):
@@ -19,26 +12,15 @@ def update_color_file(**kwargs):
 
     with open("colors.json", "w") as write_file:
         json.dump(colors, write_file)
-    minio_filepath = f"ae/colors-{AIRFLOW_ENV}.json"
-    minio_url = MINIO_URL
-    minio_bucket = MINIO_BUCKET
-    minio_user = MINIO_USER
-    minio_password = MINIO_PASSWORD
 
-    # Start client
-    client = Minio(
-        minio_url,
-        access_key=minio_user,
-        secret_key=minio_password,
-        secure=True,
+    minio_client.send_files(
+        list_files=[
+            {
+                "source_path": "",
+                "source_name": "colors.json",
+                "dest_path": "",
+                "dest_name": "colors.json",
+                "content_type": "application/json",
+            }
+        ],
     )
-
-    # Check if bucket exists
-    found = client.bucket_exists(minio_bucket)
-    if found:
-        client.fput_object(
-            bucket_name=minio_bucket,
-            object_name=minio_filepath,
-            file_path="colors.json",
-            content_type="application/json",
-        )

--- a/workflows/data_pipelines/elasticsearch/task_functions/fetch_db.py
+++ b/workflows/data_pipelines/elasticsearch/task_functions/fetch_db.py
@@ -3,27 +3,16 @@ import re
 import logging
 
 from dag_datalake_sirene.config import (
-    MINIO_BUCKET,
-    MINIO_URL,
-    MINIO_USER,
-    MINIO_PASSWORD,
     SIRENE_MINIO_DATA_PATH,
     AIRFLOW_ELK_DATA_DIR,
 )
-from dag_datalake_sirene.helpers.minio_helpers import (
-    get_files_from_prefix,
-    get_files,
-)
+from dag_datalake_sirene.helpers.minio_helpers import minio_client
 
 current_date = datetime.now().date()
 
 
 def get_latest_database(**kwargs):
-    database_files = get_files_from_prefix(
-        MINIO_URL=MINIO_URL,
-        MINIO_BUCKET=MINIO_BUCKET,
-        MINIO_USER=MINIO_USER,
-        MINIO_PASSWORD=MINIO_PASSWORD,
+    database_files = minio_client.get_files_from_prefix(
         prefix=SIRENE_MINIO_DATA_PATH,
     )
 
@@ -36,11 +25,7 @@ def get_latest_database(**kwargs):
     if dates:
         last_date = dates[-1]
         logging.info(f"***** Last database saved: {last_date}")
-        get_files(
-            MINIO_URL=MINIO_URL,
-            MINIO_BUCKET=MINIO_BUCKET,
-            MINIO_USER=MINIO_USER,
-            MINIO_PASSWORD=MINIO_PASSWORD,
+        minio_client.get_files(
             list_files=[
                 {
                     "source_path": SIRENE_MINIO_DATA_PATH,

--- a/workflows/data_pipelines/etl/DAG_extract_transform_load.py
+++ b/workflows/data_pipelines/etl/DAG_extract_transform_load.py
@@ -55,9 +55,7 @@ from dag_datalake_sirene.workflows.data_pipelines.etl.task_functions.send_notifi
     send_notification_failure_tchap,
 )
 # fmt: on
-from dag_datalake_sirene.helpers.minio_helpers import (
-    get_latest_file_minio,
-)
+from dag_datalake_sirene.helpers.minio_helpers import minio_client
 
 from dag_datalake_sirene.workflows.data_pipelines.etl.task_functions.upload_db import (
     upload_db_to_minio,
@@ -69,7 +67,6 @@ from dag_datalake_sirene.config import (
     AIRFLOW_ENV,
     DIRIG_DATABASE_LOCATION,
     EMAIL_LIST,
-    MINIO_BUCKET,
 )
 
 
@@ -167,11 +164,10 @@ with DAG(
     get_latest_dirigeants_database = PythonOperator(
         task_id="get_dirig_database",
         provide_context=True,
-        python_callable=get_latest_file_minio,
+        python_callable=minio_client.get_latest_file_minio,
         op_args=(
             f"ae/{AIRFLOW_ENV}/rne/database/",
             DIRIG_DATABASE_LOCATION,
-            MINIO_BUCKET,
         ),
     )
 

--- a/workflows/data_pipelines/etl/data_fetch_clean/etablissements.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/etablissements.py
@@ -1,11 +1,8 @@
 import logging
 import pandas as pd
 from datetime import datetime, timedelta
-from dag_datalake_sirene.helpers.minio_helpers import (
-    get_object_minio,
-)
+from dag_datalake_sirene.helpers.minio_helpers import minio_client_restricted
 from dag_datalake_sirene.config import (
-    MINIO_BUCKET_DATA_PIPELINE,
     URL_ETABLISSEMENTS,
 )
 
@@ -80,11 +77,10 @@ def download_flux(data_dir):
     else:
         year_month = datetime.today().strftime("%Y-%m")
     logging.info(f"Downloading flux for : {year_month}")
-    get_object_minio(
-        f"flux_etablissement_{year_month}.csv.gz",
+    minio_client_restricted.get_object_minio(
         "prod/insee/sirene/sirene_flux/",
+        f"flux_etablissement_{year_month}.csv.gz",
         f"{data_dir}flux_etablissement_{year_month}.csv.gz",
-        MINIO_BUCKET_DATA_PIPELINE,
     )
     df_flux = pd.read_csv(
         f"{data_dir}flux_etablissement_{year_month}.csv.gz",

--- a/workflows/data_pipelines/etl/data_fetch_clean/unite_legale.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/unite_legale.py
@@ -3,11 +3,8 @@ import shutil
 import logging
 import pandas as pd
 import requests
-from dag_datalake_sirene.helpers.minio_helpers import (
-    get_object_minio,
-)
+from dag_datalake_sirene.helpers.minio_helpers import minio_client_restricted
 from dag_datalake_sirene.config import (
-    MINIO_BUCKET_DATA_PIPELINE,
     URL_UNITE_LEGALE,
 )
 
@@ -32,11 +29,10 @@ def download_flux(data_dir):
     else:
         year_month = datetime.today().strftime("%Y-%m")
     logging.info(f"Downloading flux for : {year_month}")
-    get_object_minio(
-        f"flux_unite_legale_{year_month}.csv.gz",
+    minio_client_restricted.get_object_minio(
         "prod/insee/sirene/sirene_flux/",
+        f"flux_unite_legale_{year_month}.csv.gz",
         f"{data_dir}flux_unite_legale_{year_month}.csv.gz",
-        MINIO_BUCKET_DATA_PIPELINE,
     )
     df_iterator = pd.read_csv(
         f"{data_dir}flux_unite_legale_{year_month}.csv.gz",

--- a/workflows/data_pipelines/etl/task_functions/upload_db.py
+++ b/workflows/data_pipelines/etl/task_functions/upload_db.py
@@ -1,24 +1,16 @@
 from datetime import datetime
 
 from dag_datalake_sirene.config import (
-    MINIO_BUCKET,
-    MINIO_URL,
-    MINIO_USER,
-    MINIO_PASSWORD,
     SIRENE_MINIO_DATA_PATH,
     AIRFLOW_ETL_DATA_DIR,
 )
-from dag_datalake_sirene.helpers.minio_helpers import send_files
+from dag_datalake_sirene.helpers.minio_helpers import minio_client
 
 current_date = datetime.now().date()
 
 
 def send_to_minio(list_files):
-    send_files(
-        MINIO_URL=MINIO_URL,
-        MINIO_BUCKET=MINIO_BUCKET,
-        MINIO_USER=MINIO_USER,
-        MINIO_PASSWORD=MINIO_PASSWORD,
+    minio_client.send_files(
         list_files=list_files,
     )
 

--- a/workflows/data_pipelines/metadata/cc/task_functions.py
+++ b/workflows/data_pipelines/metadata/cc/task_functions.py
@@ -4,18 +4,12 @@ import logging
 import json
 from datetime import datetime
 from dag_datalake_sirene.helpers.tchap import send_message
-from dag_datalake_sirene.helpers.minio_helpers import (
-    send_files,
-)
+from dag_datalake_sirene.helpers.minio_helpers import minio_client
 from dag_datalake_sirene.config import (
     URL_CC_DARES,
     URL_CC_KALI,
     METADATA_CC_MINIO_PATH,
     METADATA_CC_TMP_FOLDER,
-    MINIO_URL,
-    MINIO_BUCKET,
-    MINIO_USER,
-    MINIO_PASSWORD,
 )
 
 
@@ -105,11 +99,7 @@ def create_metadata_concollective_json():
 
 
 def upload_json_file_to_minio():
-    send_files(
-        MINIO_URL=MINIO_URL,
-        MINIO_BUCKET=MINIO_BUCKET,
-        MINIO_USER=MINIO_USER,
-        MINIO_PASSWORD=MINIO_PASSWORD,
+    minio_client.send_files(
         list_files=[
             {
                 "source_path": METADATA_CC_TMP_FOLDER,
@@ -125,7 +115,7 @@ def send_notification_success_tchap():
     send_message(
         f"\U0001F7E2 Données :"
         f"\nMetadata Conventions Collectives mise à jour sur Minio "
-        f"- Bucket {MINIO_BUCKET}."
+        f"- Bucket {minio_client.bucket}."
     )
 
 

--- a/workflows/data_pipelines/rne/stock/task_functions.py
+++ b/workflows/data_pipelines/rne/stock/task_functions.py
@@ -2,12 +2,8 @@ import os
 import zipfile
 import logging
 from dag_datalake_sirene.helpers.tchap import send_message
-from dag_datalake_sirene.helpers.minio_helpers import send_files
+from dag_datalake_sirene.helpers.minio_helpers import minio_client
 from dag_datalake_sirene.config import (
-    MINIO_URL,
-    MINIO_BUCKET,
-    MINIO_USER,
-    MINIO_PASSWORD,
     RNE_STOCK_ZIP_FILE_PATH,
     RNE_STOCK_EXTRACTED_FILES_PATH,
 )
@@ -21,11 +17,7 @@ def unzip_files_and_upload_minio(**kwargs):
             z.extract(file_info, path=RNE_STOCK_EXTRACTED_FILES_PATH)
 
             logging.info(f"Saving file {file_info.filename} in MinIO.....")
-            send_files(
-                MINIO_URL=MINIO_URL,
-                MINIO_BUCKET=MINIO_BUCKET,
-                MINIO_USER=MINIO_USER,
-                MINIO_PASSWORD=MINIO_PASSWORD,
+            minio_client.send_files(
                 list_files=[
                     {
                         "source_path": RNE_STOCK_EXTRACTED_FILES_PATH,
@@ -52,7 +44,7 @@ def send_notification_success_tchap(**kwargs):
     send_message(
         f"\U0001F7E2 Données :"
         f"\nDonnées stock RNE mise à jour sur Minio "
-        f"- Bucket {MINIO_BUCKET}."
+        f"- Bucket {minio_client.bucket}."
         f"\n - Nombre de fichiers stock : {count_files_rne_stock}"
     )
 


### PR DESCRIPTION
Depends on https://github.com/etalab/annuaire-entreprises-infrastructure/pull/37

This PR introduces a `MinioClient` class to encapsulate MinIO file upload and download operations. 

Some notable changes include the utilisation of the `MinioClient` class method to handle the upload of the `colour file`. This modification has also changed the `color_url` in MinIO to be now be inside the `env` specific folder(see https://github.com/etalab/annuaire-entreprises-infrastructure/pull/37).

Additionally, the client is now employed for storing the sitemap. It's important to note that the URL for the sitemap has not been changed like the colour URL,  since the website relies on it. Any alterations in this regard should be coordinated with the website to ensure consistency. 

Certain methods within the class may appear duplicated, and this redundancy is a result of variations in destination paths between the old architecture and the new one. To address this confusion, a gradual process is underway where each file will be systematically relocated to the main environment folder, resolving these discrepancies.
