### PR TITLE
[INDEX] perf: disable refresh_interval while indexing

### DIFF
--- a/workflows/data_pipelines/elasticsearch/indexing_unite_legale.py
+++ b/workflows/data_pipelines/elasticsearch/indexing_unite_legale.py
@@ -52,7 +52,9 @@ def index_unites_legales_by_chunk(
     cursor, elastic_connection, elastic_bulk_size, elastic_index
 ):
     # Indexing performance : do not refresh the index while indexing
-    elastic_connection.indices.put_settings(index=elastic_index, body={"index.refresh_interval": -1})
+    elastic_connection.indices.put_settings(
+        index=elastic_index, body={"index.refresh_interval": -1}
+    )
 
     logger = 0
     chunk_unites_legales_sqlite = 1
@@ -101,7 +103,9 @@ def index_unites_legales_by_chunk(
         logging.info(f"Number of documents indexed: {doc_count}")
 
     # rollback to the original value
-    elastic_connection.indices.put_settings(index=elastic_index, body={"index.refresh_interval": None})
+    elastic_connection.indices.put_settings(
+        index=elastic_index, body={"index.refresh_interval": None}
+    )
 
     doc_count = elastic_connection.cat.count(
         index=elastic_index, params={"format": "json"}

--- a/workflows/data_pipelines/elasticsearch/indexing_unite_legale.py
+++ b/workflows/data_pipelines/elasticsearch/indexing_unite_legale.py
@@ -51,8 +51,13 @@ def doc_unite_legale_generator(data):
 def index_unites_legales_by_chunk(
     cursor, elastic_connection, elastic_bulk_size, elastic_index
 ):
+    # Indexing performance : do not refresh the index while indexing
+    elastic_connection.indices.put_settings(index=elastic_index, body={"index.refresh_interval": -1})
+
     logger = 0
     chunk_unites_legales_sqlite = 1
+    doc_count = 0
+
     while chunk_unites_legales_sqlite:
         chunk_unites_legales_sqlite = cursor.fetchmany(elastic_bulk_size)
         unite_legale_columns = tuple([x[0] for x in cursor.description])
@@ -89,10 +94,17 @@ def index_unites_legales_by_chunk(
             ):
                 if not success:
                     raise Exception(f"A file_access document failed: {details}")
+                else:
+                    doc_count += 1
         except Exception as e:
             logging.error(f"Failed to send to Elasticsearch: {e}")
-        doc_count = elastic_connection.cat.count(
-            index=elastic_index, params={"format": "json"}
-        )[0]["count"]
         logging.info(f"Number of documents indexed: {doc_count}")
+
+    # rollback to the original value
+    elastic_connection.indices.put_settings(index=elastic_index, body={"index.refresh_interval": None})
+
+    doc_count = elastic_connection.cat.count(
+        index=elastic_index, params={"format": "json"}
+    )[0]["count"]
+
     return doc_count


### PR DESCRIPTION
Changes coming from this branch : https://github.com/etalab/annuaire-entreprises-search-infra/tree/infra-feat-25_provisionning_vm_app

---

Basically, it will reduce the CPU load by merging segments less often and speed-up the indexing process.