### PR TITLE
[DATA-PIPELINES]feat: get daily flux SIRENE

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,6 +33,11 @@ RNE_STOCK_DATADIR = f"{RNE_STOCK_TMP_FOLDER}data"
 RNE_DAG_FOLDER = "dag_datalake_sirene/data_pipelines/"
 METADATA_CC_TMP_FOLDER = f"{AIRFLOW_DAG_TMP}metadata/cc/"
 METADATA_CC_MINIO_PATH = "metadata/cc/"
+INSEE_FLUX_TMP_FOLDER = f"{AIRFLOW_DAG_TMP}sirene/flux/"
+
+# Insee
+INSEE_SECRET_BEARER = Variable.get("SECRET_BEARER_INSEE")
+INSEE_API_URL = "https://api.insee.fr/entreprises/sirene/V3/"
 
 # Notification
 TCHAP_ANNUAIRE_WEBHOOK = Variable.get("TCHAP_ANNUAIRE_WEBHOOK", "")

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -110,7 +110,4 @@ def compare_versions_file(
 
 
 def check_if_monday():
-    if date.today().weekday() == 0:
-        return True
-    else:
-        return False
+    return date.today().weekday() == 0

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -2,9 +2,8 @@ import filecmp
 import logging
 import requests
 from ast import literal_eval
-from datetime import datetime
+from datetime import datetime, date
 from unicodedata import normalize
-from datetime import date
 from dag_datalake_sirene.config import AIRFLOW_ENV
 
 

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -4,6 +4,7 @@ import requests
 from ast import literal_eval
 from datetime import datetime
 from unicodedata import normalize
+from datetime import date
 from dag_datalake_sirene.config import AIRFLOW_ENV
 
 
@@ -107,3 +108,10 @@ def compare_versions_file(
 ):
     should_continue = not filecmp.cmp(original_file, new_file)
     return should_continue
+
+
+def check_if_monday():
+    if date.today().weekday() == 0:
+        return True
+    else:
+        return False

--- a/workflows/data_pipelines/sirene/flux/DAG.py
+++ b/workflows/data_pipelines/sirene/flux/DAG.py
@@ -1,0 +1,105 @@
+from datetime import timedelta
+
+from airflow.models import DAG
+from airflow.operators.python import PythonOperator, ShortCircuitOperator
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+from dag_datalake_sirene.workflows.data_pipelines.sirene.flux.task_functions import (
+    get_current_flux_etablissement,
+    get_current_flux_non_diffusible,
+    get_current_flux_unite_legale,
+    send_notification,
+    send_notification_stock,
+    get_stock_non_diffusible,
+    send_flux_minio,
+    send_stock_minio,
+)
+
+from dag_datalake_sirene.helpers.utils import (
+    check_if_monday,
+)
+from dag_datalake_sirene.config import (
+    AIRFLOW_DAG_TMP,
+    INSEE_FLUX_TMP_FOLDER,
+)
+
+DAG_NAME = "data_processing_sirene_flux"
+TMP_FOLDER = f"{AIRFLOW_DAG_TMP}sirene_flux/"
+
+default_args = {
+    "depends_on_past": False,
+    "email_on_failure": True,
+    "email_on_retry": False,
+    "retries": 0,
+}
+
+
+with DAG(
+    dag_id=DAG_NAME,
+    default_args=default_args,
+    schedule_interval="0 4 * * *",
+    start_date=days_ago(1),
+    dagrun_timeout=timedelta(minutes=60),
+    tags=["update", "sirene"],
+) as dag:
+    clean_previous_outputs = BashOperator(
+        task_id="clean_previous_outputs",
+        bash_command=(
+            f"rm -rf {INSEE_FLUX_TMP_FOLDER} && mkdir -p {INSEE_FLUX_TMP_FOLDER}"
+        ),
+    )
+
+    get_current_flux_unite_legale = PythonOperator(
+        task_id="get_current_flux_unite_legale",
+        python_callable=get_current_flux_unite_legale,
+    )
+
+    get_current_flux_etablissement = PythonOperator(
+        task_id="get_current_flux_etablissement",
+        python_callable=get_current_flux_etablissement,
+    )
+
+    get_current_flux_non_diffusible = PythonOperator(
+        task_id="get_current_flux_non_diffusible",
+        python_callable=get_current_flux_non_diffusible,
+    )
+
+    send_flux_minio = PythonOperator(
+        task_id="send_flux_minio",
+        python_callable=send_flux_minio,
+    )
+
+    check_if_monday = ShortCircuitOperator(
+        task_id="check_if_monday", python_callable=check_if_monday
+    )
+
+    get_stock_non_diffusible = PythonOperator(
+        task_id="get_stock_non_diffusible",
+        python_callable=get_stock_non_diffusible,
+    )
+
+    send_stock_minio = PythonOperator(
+        task_id="send_stock_minio",
+        python_callable=send_stock_minio,
+    )
+
+    send_notification = PythonOperator(
+        task_id="send_notification",
+        python_callable=send_notification,
+    )
+
+    send_notification_stock = PythonOperator(
+        task_id="send_notification_stock",
+        python_callable=send_notification_stock,
+    )
+
+    get_current_flux_unite_legale.set_upstream(clean_previous_outputs)
+    get_current_flux_etablissement.set_upstream(get_current_flux_unite_legale)
+    get_current_flux_non_diffusible.set_upstream(get_current_flux_etablissement)
+    send_flux_minio.set_upstream(get_current_flux_non_diffusible)
+    send_notification.set_upstream(send_flux_minio)
+    check_if_monday.set_upstream(send_flux_minio)
+    get_stock_non_diffusible.set_upstream(check_if_monday)
+    send_stock_minio.set_upstream(get_stock_non_diffusible)
+    send_notification_stock.set_upstream(send_stock_minio)

--- a/workflows/data_pipelines/sirene/flux/task_functions.py
+++ b/workflows/data_pipelines/sirene/flux/task_functions.py
@@ -1,0 +1,283 @@
+from datetime import datetime
+import gzip
+import pandas as pd
+import requests
+import logging
+from requests.adapters import HTTPAdapter, Retry
+import time
+from dag_datalake_sirene.helpers.minio_helpers import minio_client
+from dag_datalake_sirene.helpers.tchap import send_message
+from dag_datalake_sirene.config import (
+    INSEE_API_URL,
+    INSEE_FLUX_TMP_FOLDER,
+    INSEE_SECRET_BEARER,
+)
+
+
+CURRENT_MONTH = datetime.today().strftime("%Y-%m")
+
+session = requests.Session()
+retry = Retry(connect=3, backoff_factor=3)
+adapter = HTTPAdapter(max_retries=retry)
+session.mount("http://", adapter)
+session.mount("https://", adapter)
+
+
+def flatten_dict(dd, separator="_", prefix=""):
+    return (
+        {
+            prefix + separator + k if prefix else k: v
+            for kk, vv in dd.items()
+            for k, v in flatten_dict(vv, separator, kk).items()
+        }
+        if isinstance(dd, dict)
+        else {prefix: dd}
+    )
+
+
+def call_insee_api(api_endpoint, data_property):
+    current_cursor = "*"
+    api_data = []
+    api_headers = {"Authorization": f"Bearer {INSEE_SECRET_BEARER}"}
+    continue_fetching = True
+    request_count = 0
+
+    while continue_fetching:
+        request_count += 1000
+        if request_count % 10000 == 0:
+            logging.info(request_count)
+
+        api_response = session.get(api_endpoint + current_cursor, headers=api_headers)
+        time.sleep(0.5)
+        response_json = api_response.json()
+
+        if (
+            "header" in response_json
+            and "curseurSuivant" in response_json["header"]
+            and "curseur" in response_json["header"]
+            and response_json["header"]["curseur"]
+            != response_json["header"]["curseurSuivant"]
+        ):
+            current_cursor = response_json["header"]["curseurSuivant"]
+        else:
+            continue_fetching = False
+
+        if data_property in response_json:
+            api_data.extend(response_json[data_property])
+
+    return api_data
+
+
+def get_current_flux_unite_legale(ti):
+    query_params = (
+        f"siren?q=dateDernierTraitementUniteLegale%3A{CURRENT_MONTH}"
+        "&champs=siren,dateCreationUniteLegale,sigleUniteLegale,prenomUsuelUniteLegale,"
+        "identifiantAssociationUniteLegale,trancheEffectifsUniteLegale,"
+        "dateDernierTraitementUniteLegale,categorieEntreprise,"
+        "etatAdministratifUniteLegale,nomUniteLegale,nomUsageUniteLegale,"
+        "denominationUniteLegale,denominationUsuelle1UniteLegale,"
+        "denominationUsuelle2UniteLegale,denominationUsuelle3UniteLegale,"
+        "categorieJuridiqueUniteLegale,activitePrincipaleUniteLegale,"
+        "economieSocialeSolidaireUniteLegale,statutDiffusionUniteLegale,"
+        "societeMissionUniteLegale,anneeCategorieEntreprise,anneeEffectifsUniteLegale,"
+        "caractereEmployeurUniteLegale&nombre=1000&curseur="
+    )
+    endpoint = f"{INSEE_API_URL}{query_params}"
+
+    data = call_insee_api(endpoint, "unitesLegales")
+
+    flux = []
+    for entry in data:
+        row = entry.copy()
+        if "periodesUniteLegale" in row:
+            row.update(row["periodesUniteLegale"][0])
+            del row["periodesUniteLegale"]
+        flux.append(flatten_dict(row))
+
+    df = pd.DataFrame(flux)
+
+    file_path = f"{INSEE_FLUX_TMP_FOLDER}flux_unite_legale_{CURRENT_MONTH}.csv.gz"
+    df.to_csv(file_path, index=False, compression="gzip")
+
+    ti.xcom_push(key="nb_flux_unite_legale", value=str(df.shape[0]))
+
+
+def get_stock_non_diffusible(ti):
+    endpoint = (
+        f"{INSEE_API_URL}siret"
+        "?q=statutDiffusionUniteLegale%3AP"
+        "&champs=siren&nombre=1000&curseur="
+    )
+    data = call_insee_api(endpoint, "etablissements")
+    df = pd.DataFrame(data)
+    df.to_csv(
+        f"{INSEE_FLUX_TMP_FOLDER}stock_non_diffusible.csv.gz",
+        index=False,
+        compression="gzip",
+    )
+    ti.xcom_push(key="nb_stock_non_diffusible", value=str(df.shape[0]))
+
+
+def get_current_flux_non_diffusible(ti):
+    endpoint = (
+        f"{INSEE_API_URL}siren"
+        "?q=statutDiffusionUniteLegale%3AP"
+        "%20AND%20dateDernierTraitementUniteLegale%3A"
+        f"{CURRENT_MONTH}&champs=siren&nombre=1000&curseur="
+    )
+    data = call_insee_api(endpoint, "unitesLegales")
+    df = pd.DataFrame(data)
+    df.to_csv(
+        f"{INSEE_FLUX_TMP_FOLDER}flux_non_diffusible_{CURRENT_MONTH}.csv.gz",
+        index=False,
+        compression="gzip",
+    )
+    ti.xcom_push(key="nb_flux_non_diffusible", value=str(df.shape[0]))
+
+
+def get_current_flux_etablissement(ti):
+    query_params = (
+        f"siret?q=dateDernierTraitementEtablissement%3A{CURRENT_MONTH}"
+        "&champs=siren,siret,dateCreationEtablissement,trancheEffectifsEtablissement,"
+        "activitePrincipaleRegistreMetiersEtablissement,etablissementSiege,"
+        "numeroVoieEtablissement,dateDernierTraitementEtablissement,"
+        "anneeEffectifsEtablissement,libelleVoieEtablissement,codePostalEtablissement,"
+        "libelleCommuneEtablissement,libelleCedexEtablissement,typeVoieEtablissement,"
+        "codeCommuneEtablissement,codeCedexEtablissement,"
+        "complementAdresseEtablissement,distributionSpecialeEtablissement,"
+        "complementAdresse2Etablissement,indiceRepetition2Etablissement,"
+        "libelleCedex2Etablissement,codeCedex2Etablissement,"
+        "numeroVoie2Etablissement,typeVoie2Etablissement,libelleVoie2Etablissement,"
+        "codeCommune2Etablissement,libelleCommune2Etablissement,"
+        "distributionSpeciale2Etablissement,dateDebut,etatAdministratifEtablissement,"
+        "enseigne1Etablissement,enseigne1Etablissement,enseigne2Etablissement,"
+        "enseigne3Etablissement,denominationUsuelleEtablissement,"
+        "activitePrincipaleEtablissement,indiceRepetitionEtablissement,"
+        "libelleCommuneEtrangerEtablissement,codePaysEtrangerEtablissement,"
+        "libellePaysEtrangerEtablissement,libelleCommuneEtranger2Etablissement,"
+        "codePaysEtranger2Etablissement,libellePaysEtranger2Etablissement,"
+        "caractereEmployeurEtablissement&nombre=1000&curseur="
+    )
+    endpoint = f"{INSEE_API_URL}{query_params}"
+    data = call_insee_api(endpoint, "etablissements")
+    flux = []
+    for d in data:
+        row = d.copy()
+        if "periodesEtablissement" in row:
+            for item in row["periodesEtablissement"][0]:
+                row[item] = row["periodesEtablissement"][0][item]
+            del row["periodesEtablissement"]
+        flux.append(flatten_dict(row))
+
+    data.clear()
+
+    # We save csv.gz by batch of 100 000 for memory
+    df = pd.DataFrame(columns=[c for c in flux[0]])
+    for column in df.columns:
+        for prefix in ["adresseEtablissement_", "adresse2Etablissement_"]:
+            if prefix in column:
+                df = df.rename(columns={column: column.replace(prefix, "")})
+    file_path = f"{INSEE_FLUX_TMP_FOLDER}flux_etablissement_{CURRENT_MONTH}.csv"
+    df.to_csv(
+        file_path,
+        index=False,
+    )
+    first = 0
+    for i in range(len(flux)):
+        if i != 0 and i % 100000 == 0:
+            fluxinter = flux[first:i]
+            df = pd.DataFrame(fluxinter)
+            df.to_csv(
+                file_path,
+                mode="a",
+                index=False,
+                header=False,
+            )
+            first = i
+
+    fluxinter = flux[first : len(flux)]
+    df = pd.DataFrame(fluxinter)
+    df.to_csv(
+        file_path,
+        mode="a",
+        index=False,
+        header=False,
+    )
+
+    with open(file_path, "rb") as orig_file:
+        with gzip.open(
+            f"{file_path}.gz",
+            "wb",
+        ) as zipped_file:
+            zipped_file.writelines(orig_file)
+
+    ti.xcom_push(key="nb_flux_etablissement", value=str(df.shape[0]))
+
+
+def send_flux_minio():
+    minio_client.send_files(
+        list_files=[
+            {
+                "source_path": INSEE_FLUX_TMP_FOLDER,
+                "source_name": f"flux_unite_legale_{CURRENT_MONTH}.csv.gz",
+                "dest_path": "insee/sirene/flux/",
+                "dest_name": f"flux_unite_legale_{CURRENT_MONTH}.csv.gz",
+            },
+            {
+                "source_path": INSEE_FLUX_TMP_FOLDER,
+                "source_name": f"flux_etablissement_{CURRENT_MONTH}.csv.gz",
+                "dest_path": "insee/sirene/flux/",
+                "dest_name": f"flux_etablissement_{CURRENT_MONTH}.csv.gz",
+            },
+            {
+                "source_path": INSEE_FLUX_TMP_FOLDER,
+                "source_name": f"flux_non_diffusible_{CURRENT_MONTH}.csv.gz",
+                "dest_path": "insee/sirene/flux/",
+                "dest_name": f"flux_non_diffusible_{CURRENT_MONTH}.csv.gz",
+            },
+        ],
+    )
+
+
+def send_stock_minio():
+    minio_client.send_files(
+        list_files=[
+            {
+                "source_path": INSEE_FLUX_TMP_FOLDER,
+                "source_name": "stock_non_diffusible.csv.gz",
+                "dest_path": "insee/sirene/flux/",
+                "dest_name": "stock_non_diffusible.csv.gz",
+            }
+        ],
+    )
+
+
+def send_notification(ti):
+    nb_flux_non_diffusible = ti.xcom_pull(
+        key="nb_flux_non_diffusible", task_ids="get_current_flux_non_diffusible"
+    )
+    nb_flux_unite_legale = ti.xcom_pull(
+        key="nb_flux_unite_legale", task_ids="get_current_flux_unite_legale"
+    )
+    nb_flux_etablissement = ti.xcom_pull(
+        key="nb_flux_etablissement", task_ids="get_current_flux_etablissement"
+    )
+    send_message(
+        f"\U0001F7E2 Données Flux Sirene mises à jour - Disponibles sur Minio - Bucket "
+        f"{minio_client.bucket}\n"
+        f"- {nb_flux_non_diffusible} unités légales non diffusibles modifiées"
+        f" ce mois-ci\n"
+        f"- {nb_flux_unite_legale}  unités légales modifiées ce mois-ci\n"
+        f"- {nb_flux_etablissement} établissements modifiés ce mois-ci"
+    )
+
+
+def send_notification_stock(ti):
+    nb_stock_non_diffusible = ti.xcom_pull(
+        key="nb_stock_non_diffusible", task_ids="get_stock_non_diffusible"
+    )
+    send_message(
+        f"\U0001F7E2 Données Flux Sirene mises à jour - Disponibles sur Minio - Bucket "
+        f"{minio_client.bucket}\n"
+        f"- {nb_stock_non_diffusible} unités légales non diffusibles\n"
+    )


### PR DESCRIPTION
This PR involves relocating the workflows responsible for retrieving daily sirene flux data, including `unites légales`, `établissements`, and `non-diffusibles`, from the data.gouv pipelines to the core infrastructure. The collected data is subsequently stored in MinIO for further processing.

⚠️ PS: there is a [planned adjustment](https://github.com/etalab/annuaire-entreprises-search-infra/issues/241) to the path used in the preprocessing workflow starting Monday. This change will be implemented once the non-diffusible stock has been successfully recovered, ensuring a smooth transition in the data processing pipeline.