### PR TITLE
[DATA-PIPELINES][RNE]fix: lower rne flux page size

### DIFF
--- a/workflows/data_pipelines/rne/flux/rne_api.py
+++ b/workflows/data_pipelines/rne/flux/rne_api.py
@@ -104,8 +104,8 @@ class ApiRNEClient:
                         logging.info(f"***Memory Error changing page size to 15 : {e}")
                     else:
                         logging.info(f"***Error HTTP: {e}")
-                        url = url.replace("pageSize=100", "pageSize=20")
-                        logging.info(f"***Changing page size to 20: {e}")
+                        url = url.replace("pageSize=100", "pageSize=10")
+                        logging.info(f"***Changing page size to 10: {e}")
                         time.sleep(600)
                 else:
                     logging.error(f"Error occurred while making API request: {e}")


### PR DESCRIPTION
The RNE API has been experiencing difficulties in consistently providing comprehensive responses. To address this issue, this PR aims to mitigate the problem by reducing the page size. This adjustment is intended to lower the response size.