### PR TITLE
[DATA-PIPELINES]chore: update path source sirene flux

### DIFF
--- a/helpers/minio_helpers.py
+++ b/helpers/minio_helpers.py
@@ -6,7 +6,6 @@ import os
 from dag_datalake_sirene.config import (
     AIRFLOW_ENV,
     MINIO_BUCKET,
-    MINIO_BUCKET_DATA_PIPELINE,
     MINIO_URL,
     MINIO_USER,
     MINIO_PASSWORD,
@@ -22,11 +21,11 @@ class File(TypedDict):
 
 
 class MinIOClient:
-    def __init__(self, open_data=True):
+    def __init__(self):
         self.url = MINIO_URL
         self.user = MINIO_USER
         self.password = MINIO_PASSWORD
-        self.bucket = MINIO_BUCKET if open_data else MINIO_BUCKET_DATA_PIPELINE
+        self.bucket = MINIO_BUCKET
         self.client = Minio(
             self.url,
             access_key=self.user,
@@ -202,4 +201,3 @@ class MinIOClient:
 
 
 minio_client = MinIOClient()
-minio_client_restricted = MinIOClient(open_data=False)

--- a/workflows/data_pipelines/etl/data_fetch_clean/etablissements.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/etablissements.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd
 from datetime import datetime, timedelta
-from dag_datalake_sirene.helpers.minio_helpers import minio_client_restricted
+from dag_datalake_sirene.helpers.minio_helpers import minio_client
 from dag_datalake_sirene.config import (
     URL_ETABLISSEMENTS,
 )
@@ -77,10 +77,15 @@ def download_flux(data_dir):
     else:
         year_month = datetime.today().strftime("%Y-%m")
     logging.info(f"Downloading flux for : {year_month}")
-    minio_client_restricted.get_object_minio(
-        "prod/insee/sirene/sirene_flux/",
-        f"flux_etablissement_{year_month}.csv.gz",
-        f"{data_dir}flux_etablissement_{year_month}.csv.gz",
+    minio_client.get_files(
+        list_files=[
+            {
+                "source_path": "insee/sirene/flux/",
+                "source_name": f"flux_etablissement_{year_month}.csv.gz",
+                "dest_path": f"{data_dir}",
+                "dest_name": f"flux_etablissement_{year_month}.csv.gz",
+            }
+        ],
     )
     df_flux = pd.read_csv(
         f"{data_dir}flux_etablissement_{year_month}.csv.gz",

--- a/workflows/data_pipelines/etl/data_fetch_clean/unite_legale.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/unite_legale.py
@@ -3,7 +3,7 @@ import shutil
 import logging
 import pandas as pd
 import requests
-from dag_datalake_sirene.helpers.minio_helpers import minio_client_restricted
+from dag_datalake_sirene.helpers.minio_helpers import minio_client
 from dag_datalake_sirene.config import (
     URL_UNITE_LEGALE,
 )
@@ -29,10 +29,15 @@ def download_flux(data_dir):
     else:
         year_month = datetime.today().strftime("%Y-%m")
     logging.info(f"Downloading flux for : {year_month}")
-    minio_client_restricted.get_object_minio(
-        "prod/insee/sirene/sirene_flux/",
-        f"flux_unite_legale_{year_month}.csv.gz",
-        f"{data_dir}flux_unite_legale_{year_month}.csv.gz",
+    minio_client.get_files(
+        list_files=[
+            {
+                "source_path": "insee/sirene/flux/",
+                "source_name": f"flux_unite_legale_{year_month}.csv.gz",
+                "dest_path": f"{data_dir}",
+                "dest_name": f"flux_unite_legale_{year_month}.csv.gz",
+            }
+        ],
     )
     df_iterator = pd.read_csv(
         f"{data_dir}flux_unite_legale_{year_month}.csv.gz",


### PR DESCRIPTION
closes #241 
This PR involves transferring the Sirene flux path from the data.gouv infrastructure to the core infrastructure path. The files used will now be downloaded from the same bucket as the rest of the data utilised in our ETL process.