### PR TITLE
[DATA-PIPELINES][FIX]Remove duplicates from `elus` table

### DIFF
--- a/workflows/data_pipelines/etl/sqlite/helpers.py
+++ b/workflows/data_pipelines/etl/sqlite/helpers.py
@@ -80,9 +80,9 @@ def create_only_index(
     sqlite_client.commit_and_close_conn()
 
 
-def replace_table_model(
-    replace_table_query,
+def execute_query(
+    query,
 ):
     sqlite_client = SqliteClient(SIRENE_DATABASE_LOCATION)
-    sqlite_client.execute(replace_table_query)
-    return sqlite_client
+    sqlite_client.execute(query)
+    sqlite_client.commit_and_close_conn()

--- a/workflows/data_pipelines/etl/sqlite/queries/colter.py
+++ b/workflows/data_pipelines/etl/sqlite/queries/colter.py
@@ -19,3 +19,13 @@ create_table_elus_query = """
          fonction
      )
     """
+
+delete_duplicates_elus_query = """
+    DELETE FROM elus
+    WHERE ROWID NOT IN
+    (
+        SELECT MIN(ROWID)
+        FROM elus
+        GROUP BY siren, nom, prenom, date_naissance, sexe, fonction
+    )
+    """

--- a/workflows/data_pipelines/etl/task_functions/create_additional_data_tables.py
+++ b/workflows/data_pipelines/etl/task_functions/create_additional_data_tables.py
@@ -36,7 +36,7 @@ from dag_datalake_sirene.workflows.data_pipelines.etl.sqlite.queries import (
 
 
 def create_bilan_financiers_table():
-    return create_and_fill_table_model(
+    create_and_fill_table_model(
         table_name="bilan_financier",
         create_table_query=q_bf.create_table_bilan_financier_query,
         create_index_func=create_unique_index,
@@ -47,7 +47,7 @@ def create_bilan_financiers_table():
 
 
 def create_convention_collective_table():
-    return create_and_fill_table_model(
+    create_and_fill_table_model(
         table_name="convention_collective",
         create_table_query=q_cc.create_table_convention_collective_query,
         create_index_func=create_unique_index,
@@ -58,7 +58,7 @@ def create_convention_collective_table():
 
 
 def create_rge_table():
-    return create_and_fill_table_model(
+    create_and_fill_table_model(
         table_name="rge",
         create_table_query=q_rge.create_table_rge_query,
         create_index_func=create_index,
@@ -69,7 +69,7 @@ def create_rge_table():
 
 
 def create_uai_table():
-    return create_and_fill_table_model(
+    create_and_fill_table_model(
         table_name="uai",
         create_table_query=q_uai.create_table_uai_query,
         create_index_func=create_index,
@@ -80,7 +80,7 @@ def create_uai_table():
 
 
 def create_finess_table():
-    return create_and_fill_table_model(
+    create_and_fill_table_model(
         table_name="finess",
         create_table_query=q_finess.create_table_finess_query,
         create_index_func=create_index,
@@ -108,7 +108,7 @@ def create_agence_bio_table():
 
 
 def create_organisme_formation_table():
-    return create_and_fill_table_model(
+    create_and_fill_table_model(
         table_name="organisme_formation",
         create_table_query=q_of.create_table_organisme_formation_query,
         create_index_func=create_index,
@@ -119,7 +119,7 @@ def create_organisme_formation_table():
 
 
 def create_spectacle_table():
-    return create_and_fill_table_model(
+    create_and_fill_table_model(
         table_name="spectacle",
         create_table_query=q_es.create_table_spectacle_query,
         create_index_func=create_index,
@@ -130,7 +130,7 @@ def create_spectacle_table():
 
 
 def create_egapro_table():
-    return create_and_fill_table_model(
+    create_and_fill_table_model(
         table_name="egapro",
         create_table_query=q_egapro.create_table_egapro_query,
         create_index_func=create_index,
@@ -141,7 +141,7 @@ def create_egapro_table():
 
 
 def create_colter_table():
-    return create_and_fill_table_model(
+    create_and_fill_table_model(
         table_name="colter",
         create_table_query=q_ct.create_table_colter_query,
         create_index_func=create_index,
@@ -160,11 +160,11 @@ def create_elu_table():
         index_column="siren",
         preprocess_table_data=ct.preprocess_elus_data,
     )
-    return execute_query(q_ct.delete_duplicates_elus_query)
+    execute_query(q_ct.delete_duplicates_elus_query)
 
 
 def create_ess_table():
-    return create_and_fill_table_model(
+    create_and_fill_table_model(
         table_name="ess_france",
         create_table_query=q_ess.create_table_ess_query,
         create_index_func=create_index,

--- a/workflows/data_pipelines/etl/task_functions/create_additional_data_tables.py
+++ b/workflows/data_pipelines/etl/task_functions/create_additional_data_tables.py
@@ -17,6 +17,7 @@ from dag_datalake_sirene.workflows.data_pipelines.etl.sqlite.helpers import (
     create_index,
     create_and_fill_table_model,
     create_only_index,
+    execute_query,
 )
 
 from dag_datalake_sirene.workflows.data_pipelines.etl.sqlite.queries import (
@@ -151,7 +152,7 @@ def create_colter_table():
 
 
 def create_elu_table():
-    return create_and_fill_table_model(
+    create_and_fill_table_model(
         table_name="elus",
         create_table_query=q_ct.create_table_elus_query,
         create_index_func=create_index,
@@ -159,6 +160,7 @@ def create_elu_table():
         index_column="siren",
         preprocess_table_data=ct.preprocess_elus_data,
     )
+    return execute_query(q_ct.delete_duplicates_elus_query)
 
 
 def create_ess_table():

--- a/workflows/data_pipelines/etl/task_functions/create_etablissements_tables.py
+++ b/workflows/data_pipelines/etl/task_functions/create_etablissements_tables.py
@@ -13,9 +13,9 @@ from dag_datalake_sirene.workflows.data_pipelines.etl.data_fetch_clean.etablisse
 from dag_datalake_sirene.workflows.data_pipelines.etl.sqlite.helpers import (
     get_table_count,
     create_index,
-    replace_table_model,
     create_table_model,
     create_unique_index,
+    execute_query,
 )
 from dag_datalake_sirene.workflows.data_pipelines.etl.sqlite.queries.etablissements\
     import (
@@ -109,17 +109,15 @@ def create_siege_only_table(**kwargs):
 
 
 def replace_etablissements_table():
-    sqlite_client = replace_table_model(
-        replace_table_query=replace_table_etablissement_query,
+    return execute_query(
+        query=replace_table_etablissement_query,
     )
-    sqlite_client.commit_and_close_conn()
 
 
 def replace_siege_only_table():
-    sqlite_client = replace_table_model(
-        replace_table_query=replace_table_siret_siege_query,
+    return execute_query(
+        query=replace_table_siret_siege_query,
     )
-    sqlite_client.commit_and_close_conn()
 
 
 def count_nombre_etablissements():

--- a/workflows/data_pipelines/etl/task_functions/create_unite_legale_tables.py
+++ b/workflows/data_pipelines/etl/task_functions/create_unite_legale_tables.py
@@ -24,8 +24,8 @@ from dag_datalake_sirene.workflows.data_pipelines.etl.sqlite.helpers import (
     create_index,
     create_table_model,
     create_unique_index,
+    execute_query,
     get_table_count,
-    replace_table_model,
 )
 from dag_datalake_sirene.config import AIRFLOW_ETL_DATA_DIR
 from dag_datalake_sirene.config import (
@@ -86,10 +86,9 @@ def create_flux_unite_legale_table(**kwargs):
 
 
 def replace_unite_legale_table():
-    sqlite_client = replace_table_model(
-        replace_table_query=replace_table_unite_legale_query,
+    return execute_query(
+        query=replace_table_unite_legale_query,
     )
-    sqlite_client.commit_and_close_conn()
 
 
 def add_rne_data_to_unite_legale_table(**kwargs):


### PR DESCRIPTION
This PR aims to address the indexing failure of [METROPOLE DU GRAND PARIS (MGP)](https://annuaire-entreprises.data.gouv.fr/entreprise/200054781) in Elasticsearch, which occurs because it exceeds the allowed number of nested documents (20000). This issue arises primarily from numerous duplicates for each `elu`. 

The proposed solution in this PR is to remove these duplicates before indexing, rather than solely handling them on the API side.