### PR TITLE
[INDEXING]Add `list_idcc` field to `unite legale` object

### DIFF
--- a/workflows/data_pipelines/elasticsearch/mapping_index.py
+++ b/workflows/data_pipelines/elasticsearch/mapping_index.py
@@ -303,6 +303,7 @@ class UniteLegaleMapping(InnerDoc):
     identifiant_association_unite_legale = Keyword()
     liste_dirigeants = Text(analyzer=annuaire_analyzer)
     liste_elus = Text(analyzer=annuaire_analyzer)
+    list_idcc = Text()
     nature_juridique_unite_legale = Keyword()
     nom = Text(analyzer=annuaire_analyzer)
     nom_raison_sociale = Text(analyzer=annuaire_analyzer, fields={"keyword": Keyword()})

--- a/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
+++ b/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
@@ -31,6 +31,8 @@ select_fields_to_index_query = """SELECT
             ul.est_societe_mission as est_societe_mission,
             ul.annee_categorie_entreprise as annee_categorie_entreprise,
             ul.annee_tranche_effectif_salarie as annee_tranche_effectif_salarie,
+            (SELECT liste_idcc_by_siren FROM convention_collective WHERE
+                        siren = ul.siren) as liste_idcc,
             (SELECT count FROM count_etab ce WHERE ce.siren = ul.siren) as
             nombre_etablissements,
             (SELECT count FROM count_etab_ouvert ceo WHERE ceo.siren = ul.siren) as
@@ -191,8 +193,8 @@ select_fields_to_index_query = """SELECT
                         liste_finess,
                         (SELECT liste_id_bio FROM agence_bio WHERE siret = s.siret) as
                         liste_id_bio,
-                        (SELECT liste_idcc FROM convention_collective WHERE siret =
-                        s.siret) as liste_idcc,
+                        (SELECT liste_idcc_by_siret FROM convention_collective
+                        WHERE siret = s.siret) as liste_idcc,
                         (SELECT liste_rge FROM rge WHERE siret = s.siret) as liste_rge,
                         (SELECT liste_uai FROM uai WHERE siret = s.siret) as liste_uai,
                         s.longitude as longitude,
@@ -322,8 +324,8 @@ select_fields_to_index_query = """SELECT
                         liste_finess,
                         (SELECT liste_id_bio FROM agence_bio WHERE siret = s.siret) as
                         liste_id_bio,
-                        (SELECT liste_idcc FROM convention_collective WHERE siret =
-                        s.siret) as liste_idcc,
+                        (SELECT liste_idcc_by_siret FROM convention_collective WHERE
+                        siret = s.siret) as liste_idcc,
                         (SELECT liste_rge FROM rge WHERE siret = s.siret) as liste_rge,
                         (SELECT liste_uai FROM uai WHERE siret = s.siret) as liste_uai,
                         s.longitude as longitude,

--- a/workflows/data_pipelines/etl/data_fetch_clean/convention_collective.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/convention_collective.py
@@ -8,22 +8,53 @@ def preprocess_convcollective_data(data_dir):
     with open(data_dir + "convcollective-download.csv", "wb") as f:
         for chunk in r.iter_content(1024):
             f.write(chunk)
+
+    # Read data into DataFrame
     df_conv_coll = pd.read_csv(
         data_dir + "convcollective-download.csv",
         dtype=str,
         names=["mois", "siret", "idcc", "date_maj"],
         header=0,
     )
-    # df_conv_coll["siren"] = df_conv_coll["siret"].str[0:9]
-    df_conv_coll = df_conv_coll[df_conv_coll["siret"].notna()]
-    df_conv_coll["idcc"] = df_conv_coll["idcc"].apply(lambda x: str(x).replace(" ", ""))
-    df_liste_cc = (
+
+    # Preprocessing
+    df_conv_coll["siren"] = df_conv_coll["siret"].str[0:9]
+    df_conv_coll = df_conv_coll.dropna(subset=["siret"])
+    df_conv_coll["idcc"] = df_conv_coll["idcc"].str.replace(" ", "")
+
+    df_liste_cc_by_siret = (
         df_conv_coll.groupby(by=["siret"])["idcc"]
         .apply(list)
-        .reset_index(name="liste_idcc")
+        .reset_index(name="liste_idcc_by_siret")
     )
     # df_liste_cc["siren"] = df_liste_cc["siret"].str[0:9]
-    df_liste_cc["liste_idcc"] = df_liste_cc["liste_idcc"].astype(str)
-    del df_conv_coll
+    df_liste_cc_by_siret["liste_idcc_by_siret"] = df_liste_cc_by_siret[
+        "liste_idcc_by_siret"
+    ].astype(str)
+    df_liste_cc_by_siret["siren"] = df_liste_cc_by_siret["siret"].str[0:9]
 
-    return df_liste_cc
+    # Group by siren and construct the dictionary
+    siren_idcc_dict = {}
+    for siren, group in df_conv_coll.groupby("siren"):
+        idcc_siret_dict = {}
+        for _, row in group.iterrows():
+            idcc = row["idcc"]
+            siret = row["siret"]
+            if idcc not in idcc_siret_dict:
+                idcc_siret_dict[idcc] = []
+            idcc_siret_dict[idcc].append(siret)
+        siren_idcc_dict[siren] = idcc_siret_dict
+
+    # Create DataFrame from the dictionary
+    df_liste_cc_by_siren = pd.DataFrame(
+        siren_idcc_dict.items(), columns=["siren", "liste_idcc_by_siren"]
+    )
+
+    merged_df = df_liste_cc_by_siret.merge(df_liste_cc_by_siren, on="siren", how="left")
+
+    merged_df["liste_idcc_by_siren"] = merged_df["liste_idcc_by_siren"].astype(str)
+
+    del df_liste_cc_by_siren
+    del df_liste_cc_by_siret
+
+    return merged_df

--- a/workflows/data_pipelines/etl/sqlite/helpers.py
+++ b/workflows/data_pipelines/etl/sqlite/helpers.py
@@ -44,6 +44,10 @@ def create_and_fill_table_model(
     sqlite_client.execute(drop_table(table_name))
     sqlite_client.execute(create_table_query)
     sqlite_client.execute(create_index_func(index_name, table_name, index_column))
+    if table_name == "convention_collective":
+        sqlite_client.execute(
+            create_index("index_siren_convention_collective", table_name, "siren")
+        )
     df_table = preprocess_table_data(data_dir=AIRFLOW_ETL_DATA_DIR)
     df_table.to_sql(table_name, sqlite_client.db_conn, if_exists="append", index=False)
     del df_table

--- a/workflows/data_pipelines/etl/sqlite/helpers.py
+++ b/workflows/data_pipelines/etl/sqlite/helpers.py
@@ -44,10 +44,6 @@ def create_and_fill_table_model(
     sqlite_client.execute(drop_table(table_name))
     sqlite_client.execute(create_table_query)
     sqlite_client.execute(create_index_func(index_name, table_name, index_column))
-    if table_name == "convention_collective":
-        sqlite_client.execute(
-            create_index("index_siren_convention_collective", table_name, "siren")
-        )
     df_table = preprocess_table_data(data_dir=AIRFLOW_ETL_DATA_DIR)
     df_table.to_sql(table_name, sqlite_client.db_conn, if_exists="append", index=False)
     del df_table

--- a/workflows/data_pipelines/etl/sqlite/queries/convention_collective.py
+++ b/workflows/data_pipelines/etl/sqlite/queries/convention_collective.py
@@ -2,6 +2,8 @@ create_table_convention_collective_query = """
      CREATE TABLE IF NOT EXISTS convention_collective
      (
          siret,
-         liste_idcc
+         siren,
+         liste_idcc_by_siren,
+         liste_idcc_by_siret
      )
     """

--- a/workflows/data_pipelines/etl/task_functions/create_additional_data_tables.py
+++ b/workflows/data_pipelines/etl/task_functions/create_additional_data_tables.py
@@ -55,6 +55,12 @@ def create_convention_collective_table():
         index_column="siret",
         preprocess_table_data=cc.preprocess_convcollective_data,
     )
+    create_only_index(
+        table_name="convention_collective",
+        create_index_func=create_index,
+        index_name="index_siren_convention_collective",
+        index_column="siren",
+    )
 
 
 def create_rge_table():


### PR DESCRIPTION
This pull PR a new field called 'liste_idcc' to the 'unite_legale' index in Elasticsearch. For each SIREN :

```
liste_idcc = {
  [IDCC_A]: [siret1, siret2],
  [IDCC_B]: [siret3, siret4],
}
```

The 'liste_idcc' field is indexed as a string in Elasticsearch to prevent excessive nesting of objects per document.