### PR TITLE
[NEW DATA][MARCHE INCLUSION]Add marche inclusion data to index

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,10 +34,14 @@ RNE_DAG_FOLDER = "dag_datalake_sirene/data_pipelines/"
 METADATA_CC_TMP_FOLDER = f"{AIRFLOW_DAG_TMP}metadata/cc/"
 METADATA_CC_MINIO_PATH = "metadata/cc/"
 INSEE_FLUX_TMP_FOLDER = f"{AIRFLOW_DAG_TMP}sirene/flux/"
+MARCHE_INCLUSION_TMP_FOLDER = f"{AIRFLOW_DAG_TMP}marche_inclusion/"
 
 # Insee
 INSEE_SECRET_BEARER = Variable.get("SECRET_BEARER_INSEE", None)
 INSEE_API_URL = "https://api.insee.fr/entreprises/sirene/V3/"
+
+# Marche Inclusion
+SECRET_TOKEN_MARCHE_INCLUSION = Variable.get("SECRET_TOKEN_MARCHE_INCLUSION", "")
 
 # Notification
 TCHAP_ANNUAIRE_WEBHOOK = Variable.get("TCHAP_ANNUAIRE_WEBHOOK", "")
@@ -56,6 +60,9 @@ RNE_FTP_URL = Variable.get("RNE_FTP_URL", "")
 RNE_AUTH = json.loads(Variable.get("RNE_AUTH", "[]"))
 RNE_API_TOKEN_URL = "https://registre-national-entreprises.inpi.fr/api/sso/login"
 RNE_API_DIFF_URL = "https://registre-national-entreprises.inpi.fr/api/companies/diff?"
+
+# MARCHE INCLUSION
+MARCHE_INCLUSION_API_URL = "https://lemarche.inclusion.beta.gouv.fr/api/siae/?"
 
 # AIO
 AIO_URL = Variable.get("AIO_URL", None)

--- a/config.py
+++ b/config.py
@@ -40,9 +40,6 @@ MARCHE_INCLUSION_TMP_FOLDER = f"{AIRFLOW_DAG_TMP}marche_inclusion/"
 INSEE_SECRET_BEARER = Variable.get("SECRET_BEARER_INSEE", None)
 INSEE_API_URL = "https://api.insee.fr/entreprises/sirene/V3/"
 
-# Marche Inclusion
-SECRET_TOKEN_MARCHE_INCLUSION = Variable.get("SECRET_TOKEN_MARCHE_INCLUSION", "")
-
 # Notification
 TCHAP_ANNUAIRE_WEBHOOK = Variable.get("TCHAP_ANNUAIRE_WEBHOOK", "")
 TCHAP_ANNUAIRE_ROOM_ID = Variable.get("TCHAP_ANNUAIRE_ROOM_ID", "")
@@ -63,7 +60,7 @@ RNE_API_DIFF_URL = "https://registre-national-entreprises.inpi.fr/api/companies/
 
 # MARCHE INCLUSION
 MARCHE_INCLUSION_API_URL = "https://lemarche.inclusion.beta.gouv.fr/api/siae/?"
-
+SECRET_TOKEN_MARCHE_INCLUSION = Variable.get("SECRET_TOKEN_MARCHE_INCLUSION", "")
 # AIO
 AIO_URL = Variable.get("AIO_URL", None)
 COLOR_URL = Variable.get("COLOR_URL", None)

--- a/workflows/data_pipelines/elasticsearch/mapping_index.py
+++ b/workflows/data_pipelines/elasticsearch/mapping_index.py
@@ -294,6 +294,7 @@ class UniteLegaleMapping(InnerDoc):
     est_qualiopi = Boolean()
     est_rge = Boolean()
     est_service_public = Boolean()
+    est_siae = Boolean()
     est_societe_mission = Keyword()
     est_uai = Boolean()
     etablissements = Nested(EtablissementMapping)
@@ -318,6 +319,7 @@ class UniteLegaleMapping(InnerDoc):
     slug = Text()
     statut_diffusion_unite_legale = Keyword()
     statut_entrepreneur_spectacle = Text()
+    type_siae = Text()
     tranche_effectif_salarie_unite_legale = Keyword()
 
 

--- a/workflows/data_pipelines/elasticsearch/process_unites_legales.py
+++ b/workflows/data_pipelines/elasticsearch/process_unites_legales.py
@@ -164,7 +164,6 @@ def process_unites_legales(chunk_unites_legales_sqlite):
         )
 
         # ESS
-
         unite_legale_processed["est_ess"] = is_ess(
             sqlite_str_to_bool(unite_legale["est_ess_france"]),
             unite_legale["economie_sociale_solidaire_unite_legale"],

--- a/workflows/data_pipelines/elasticsearch/process_unites_legales.py
+++ b/workflows/data_pipelines/elasticsearch/process_unites_legales.py
@@ -175,6 +175,11 @@ def process_unites_legales(chunk_unites_legales_sqlite):
             unite_legale["egapro_renseignee"]
         )
 
+        # Marche Inclusion
+        unite_legale_processed["est_siae"] = sqlite_str_to_bool(
+            unite_legale["est_siae"]
+        )
+
         # Etablissements
         etablissements_processed, complements = format_etablissements_and_complements(
             unite_legale["etablissements"],

--- a/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
+++ b/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
@@ -379,7 +379,11 @@ select_fields_to_index_query = """SELECT
             (SELECT est_qualiopi FROM organisme_formation WHERE siren = ul.siren) as
             est_qualiopi,
             (SELECT liste_id_organisme_formation FROM organisme_formation
-            WHERE siren = ul.siren)  as liste_id_organisme_formation
+            WHERE siren = ul.siren)  as liste_id_organisme_formation,
+            SELECT mi.est_siae AS est_siae,
+                    mi.type_siae AS type_siae
+                    FROM marche_inclusion AS mi
+                    JOIN ul ON mi.siren = ul.siren
             FROM
                 unite_legale ul
             LEFT JOIN

--- a/workflows/data_pipelines/etl/DAG_extract_transform_load.py
+++ b/workflows/data_pipelines/etl/DAG_extract_transform_load.py
@@ -35,6 +35,7 @@ from dag_datalake_sirene.workflows.data_pipelines.etl.task_functions.\
     create_spectacle_table,
     create_uai_table,
     create_convention_collective_table,
+    create_marche_inclusion_table,
 )
 from dag_datalake_sirene.workflows.data_pipelines.etl.task_functions.\
     create_dirigeants_tables import (
@@ -311,6 +312,12 @@ with DAG(
         python_callable=create_colter_table,
     )
 
+    create_marche_inclusion_table = PythonOperator(
+        task_id="create_marche_inclusion_table",
+        provide_context=True,
+        python_callable=create_marche_inclusion_table,
+    )
+
     send_database_to_minio = PythonOperator(
         task_id="upload_db_to_minio",
         provide_context=True,
@@ -384,8 +391,9 @@ with DAG(
     create_egapro_table.set_upstream(create_spectacle_table)
     create_colter_table.set_upstream(create_egapro_table)
     create_elu_table.set_upstream(create_colter_table)
+    create_marche_inclusion_table.set_upstream(create_elu_table)
 
-    send_database_to_minio.set_upstream(create_elu_table)
+    send_database_to_minio.set_upstream(create_marche_inclusion_table)
 
     clean_folder.set_upstream(send_database_to_minio)
     send_email.set_upstream(clean_folder)

--- a/workflows/data_pipelines/etl/data_fetch_clean/marche_inclusion.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/marche_inclusion.py
@@ -6,7 +6,7 @@ def preprocess_marche_inclusion_data(data_dir):
     minio_client.get_files(
         list_files=[
             {
-                "source_path": "marche_inclusion",
+                "source_path": "marche_inclusion/",
                 "source_name": "stock_marche_inclusion.csv",
                 "dest_path": f"{data_dir}",
                 "dest_name": "marche_inclusion.csv",
@@ -25,6 +25,7 @@ def preprocess_marche_inclusion_data(data_dir):
         .reset_index()
     )
     df_siae_grouped.rename(columns={"kind_parent": "type_siae"}, inplace=True)
+    df_siae_grouped["type_siae"] = df_siae_grouped["type_siae"].astype(str)
 
     df_siae_grouped["est_siae"] = True
 

--- a/workflows/data_pipelines/etl/data_fetch_clean/marche_inclusion.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/marche_inclusion.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from dag_datalake_sirene.helpers.minio_helpers import minio_client
+
+
+def preprocess_marche_inclusion_data(data_dir):
+    minio_client.get_files(
+        list_files=[
+            {
+                "source_path": "marche_inclusion",
+                "source_name": "stock_marche_inclusion.csv",
+                "dest_path": f"{data_dir}",
+                "dest_name": "marche_inclusion.csv",
+            }
+        ],
+    )
+    df_siae = pd.read_csv(
+        f"{data_dir}marche_inclusion.csv",
+        dtype=str,
+    )
+    df_siae["siren"] = df_siae["siret"].str[0:9]
+
+    df_siae_grouped = (
+        df_siae.groupby("siren")["kind_parent"]
+        .agg(lambda x: list(set(x)))
+        .reset_index()
+    )
+    df_siae_grouped.rename(columns={"kind_parent": "type_siae"}, inplace=True)
+
+    df_siae_grouped["est_siae"] = True
+
+    del df_siae
+
+    return df_siae_grouped

--- a/workflows/data_pipelines/etl/sqlite/queries/marche_inclusion.py
+++ b/workflows/data_pipelines/etl/sqlite/queries/marche_inclusion.py
@@ -1,0 +1,9 @@
+create_table_marche_inclusion_query = """
+     CREATE TABLE IF NOT EXISTS marche_inclusion
+     (
+         siren,
+         type_siae,
+         est_siae
+
+     )
+    """

--- a/workflows/data_pipelines/etl/task_functions/create_additional_data_tables.py
+++ b/workflows/data_pipelines/etl/task_functions/create_additional_data_tables.py
@@ -10,6 +10,7 @@ from dag_datalake_sirene.workflows.data_pipelines.etl.data_fetch_clean import (
     organisme_formation as of,
     rge,
     uai,
+    marche_inclusion as mi,
 )
 
 from dag_datalake_sirene.workflows.data_pipelines.etl.sqlite.helpers import (
@@ -32,6 +33,7 @@ from dag_datalake_sirene.workflows.data_pipelines.etl.sqlite.queries import (
     entrepreneur_spectacle as q_es,
     colter as q_ct,
     uai as q_uai,
+    marche_inclusion as q_mi,
 )
 
 
@@ -177,4 +179,15 @@ def create_ess_table():
         index_name="index_ess",
         index_column="siren",
         preprocess_table_data=ess.preprocess_ess_france_data,
+    )
+
+
+def create_marche_inclusion_table():
+    create_and_fill_table_model(
+        table_name="marche_inclusion",
+        create_table_query=q_mi.create_table_marche_inclusion_query,
+        create_index_func=create_index,
+        index_name="index_marche_inclusion",
+        index_column="siren",
+        preprocess_table_data=mi.preprocess_marche_inclusion_data,
     )

--- a/workflows/data_pipelines/marche_inclusion/DAG.py
+++ b/workflows/data_pipelines/marche_inclusion/DAG.py
@@ -1,0 +1,56 @@
+from datetime import timedelta
+
+from airflow.models import DAG
+from airflow.operators.python import PythonOperator
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+# fmt: off
+from dag_datalake_sirene.workflows.data_pipelines.marche_inclusion.task_functions\
+    import (
+    get_structures_siae,
+    send_file_minio,
+)
+# fmt: on
+from dag_datalake_sirene.config import (
+    AIRFLOW_DAG_TMP,
+    MARCHE_INCLUSION_TMP_FOLDER,
+)
+
+DAG_NAME = "data_processing_marche_inclusion"
+TMP_FOLDER = f"{AIRFLOW_DAG_TMP}marche_inclusion/"
+
+default_args = {
+    "depends_on_past": False,
+    "email_on_failure": True,
+    "email_on_retry": False,
+    "retries": 0,
+}
+
+
+with DAG(
+    dag_id=DAG_NAME,
+    default_args=default_args,
+    schedule_interval="10 0 * * *",  # Run at 12:10 AM every day
+    start_date=days_ago(1),
+    dagrun_timeout=timedelta(minutes=60),
+    tags=["marche inclusion"],
+) as dag:
+    clean_previous_outputs = BashOperator(
+        task_id="clean_previous_outputs",
+        bash_command=(
+            f"rm -rf {MARCHE_INCLUSION_TMP_FOLDER} && "
+            f"mkdir -p {MARCHE_INCLUSION_TMP_FOLDER}"
+        ),
+    )
+
+    get_structures_siae = PythonOperator(
+        task_id="get_structures_siae",
+        python_callable=get_structures_siae,
+    )
+    send_file_minio = PythonOperator(
+        task_id="send_file_minio",
+        python_callable=send_file_minio,
+    )
+
+    get_structures_siae.set_upstream(clean_previous_outputs)
+    send_file_minio.set_upstream(get_structures_siae)

--- a/workflows/data_pipelines/marche_inclusion/task_functions.py
+++ b/workflows/data_pipelines/marche_inclusion/task_functions.py
@@ -1,0 +1,56 @@
+import csv
+import requests
+import logging
+from dag_datalake_sirene.helpers.minio_helpers import minio_client
+from dag_datalake_sirene.config import (
+    MARCHE_INCLUSION_API_URL,
+    MARCHE_INCLUSION_TMP_FOLDER,
+    SECRET_TOKEN_MARCHE_INCLUSION,
+)
+
+
+def call_api_marche_inclusion(number_of_strctures):
+    query_params = f"token={SECRET_TOKEN_MARCHE_INCLUSION}&limit={number_of_strctures}"
+
+    endpoint = f"{MARCHE_INCLUSION_API_URL}{query_params}"
+
+    response = requests.get(endpoint)
+    data = response.json()
+    return data
+
+
+def save_siae_to_csv(data, file_path):
+    csv_data = [
+        [result["siret"], result["kind_parent"]] for result in data.get("results", [])
+    ]
+    with open(file_path, "w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(["siret", "kind_parent"])
+        writer.writerows(csv_data)
+
+
+def get_structures_siae():
+    number_of_structures = 20000
+    response_data = call_api_marche_inclusion(number_of_structures)
+    actual_number_of_structures = response_data.get("count", 0)
+    logging.info(f"Number of structures: {actual_number_of_structures}")
+
+    if actual_number_of_structures > number_of_structures:
+        number_of_structures = actual_number_of_structures
+        response_data = call_api_marche_inclusion(number_of_structures)
+
+    file_path = f"{MARCHE_INCLUSION_TMP_FOLDER}marche_inclusion.csv"
+    save_siae_to_csv(response_data, file_path)
+
+
+def send_file_minio():
+    minio_client.send_files(
+        list_files=[
+            {
+                "source_path": MARCHE_INCLUSION_TMP_FOLDER,
+                "source_name": "marche_inclusion.csv",
+                "dest_path": "marche_inclusion/",
+                "dest_name": "stock_marche_inclusion.csv",
+            },
+        ],
+    )


### PR DESCRIPTION
Related to https://github.com/etalab/annuaire-entreprises-search-api/issues/304.

The changes implemented in this PR :

1. Creation of a daily DAG that interacts with the `Marché de l'Inclusion` API, retrieving information about all structures and storing them in a CSV file within MinIO.
2. Processing this retrieved data in the daily ETL workflow.
3. Indexing the processed data in Elasticsearch.
4. Addition of two fields, "est_siae" and "type_siae", at the SIREN level in Elasticsearch.

Before deploying this to production, there is a task pending:
- [ ] Adding the API token to the environment file (https://github.com/etalab/annuaire-entreprises-infrastructure/pull/79).
