### PR TITLE
[DATA-PIPELINES]Update dag sequence order

### DIFF
--- a/workflows/data_pipelines/elasticsearch/DAG_index_data.py
+++ b/workflows/data_pipelines/elasticsearch/DAG_index_data.py
@@ -66,7 +66,7 @@ with DAG(
     schedule_interval="0 0 * * *",  # Run every day at midnight
     start_date=datetime(2023, 9, 4),
     dagrun_timeout=timedelta(minutes=60 * 12),
-    tags=["siren"],
+    tags=["index", "elasticsearch"],
     catchup=False,  # False to ignore past runs
     on_failure_callback=send_notification_failure_tchap,
     max_active_runs=1,

--- a/workflows/data_pipelines/etl/DAG_extract_transform_load.py
+++ b/workflows/data_pipelines/etl/DAG_extract_transform_load.py
@@ -94,7 +94,7 @@ with DAG(
     schedule_interval="0 5 * * *",  # Run everyday at 5 am
     start_date=datetime(2023, 12, 27),
     dagrun_timeout=timedelta(minutes=60 * 5),
-    tags=["preprocessing", "data"],
+    tags=["database", "all-data"],
     catchup=False,  # False to ignore past runs
     on_failure_callback=send_notification_failure_tchap,
     max_active_runs=1,

--- a/workflows/data_pipelines/etl/DAG_extract_transform_load.py
+++ b/workflows/data_pipelines/etl/DAG_extract_transform_load.py
@@ -91,7 +91,7 @@ default_args = {
 with DAG(
     dag_id=AIRFLOW_ETL_DAG_NAME,
     default_args=default_args,
-    schedule_interval="0 18 * * *",  # Run everyday at 18h
+    schedule_interval="0 5 * * *",  # Run everyday at 5 am
     start_date=datetime(2023, 12, 27),
     dagrun_timeout=timedelta(minutes=60 * 5),
     tags=["preprocessing", "data"],

--- a/workflows/data_pipelines/marche_inclusion/DAG.py
+++ b/workflows/data_pipelines/marche_inclusion/DAG.py
@@ -30,7 +30,7 @@ default_args = {
 with DAG(
     dag_id=DAG_NAME,
     default_args=default_args,
-    schedule_interval="10 0 * * *",  # Run at 12:10 AM every day
+    schedule_interval="0 1 * * *",  # Run daily at 1 AM
     start_date=days_ago(1),
     dagrun_timeout=timedelta(minutes=60),
     tags=["marche inclusion"],

--- a/workflows/data_pipelines/rne/database/DAG.py
+++ b/workflows/data_pipelines/rne/database/DAG.py
@@ -32,7 +32,7 @@ with DAG(
     max_active_runs=1,
     catchup=False,
     dagrun_timeout=timedelta(minutes=(60 * 30)),
-    tags=["data_processing", "rne", "dirigeants", "database"],
+    tags=["rne", "database"],
     params={},
 ) as dag:
     clean_previous_outputs = BashOperator(

--- a/workflows/data_pipelines/rne/flux/DAG.py
+++ b/workflows/data_pipelines/rne/flux/DAG.py
@@ -23,12 +23,12 @@ with DAG(
     dag_id="get_flux_rne",
     default_args=default_args,
     start_date=datetime(2023, 10, 18),
-    schedule_interval="0 0 * * *",  # Run every day at midnight
+    schedule_interval="0 1 * * *",  # Run every day at 1 AM
     catchup=False,
     max_active_runs=1,
     dagrun_timeout=timedelta(days=30),
     on_failure_callback=send_notification_failure_tchap,
-    tags=["api", "rne", "flux"],
+    tags=["rne", "flux"],
     params={},
 ) as dag:
     clean_previous_outputs = BashOperator(

--- a/workflows/data_pipelines/sirene/flux/DAG.py
+++ b/workflows/data_pipelines/sirene/flux/DAG.py
@@ -38,10 +38,10 @@ default_args = {
 with DAG(
     dag_id=DAG_NAME,
     default_args=default_args,
-    schedule_interval="0 4 * * *",
+    schedule_interval="0 4 * * *", # Daily at 4 AM
     start_date=days_ago(1),
     dagrun_timeout=timedelta(minutes=60),
-    tags=["update", "sirene"],
+    tags=["sirene", "flux"],
 ) as dag:
     clean_previous_outputs = BashOperator(
         task_id="clean_previous_outputs",


### PR DESCRIPTION
DAG scheduling has been rescheduled to later hours of the night to ensure that most data sources have been updated for the day. For further information, please refer to the provided source.