### PR TITLE
[CHORE]Decrease emailing about DAG status updates and notifications

### DIFF
--- a/workflows/data_pipelines/elasticsearch/DAG_snapshot_data.py
+++ b/workflows/data_pipelines/elasticsearch/DAG_snapshot_data.py
@@ -3,15 +3,19 @@ from datetime import datetime, timedelta
 from airflow.models import DAG
 from airflow.operators.python import PythonOperator
 
-from dag_datalake_sirene.workflows.data_pipelines.elasticsearch.task_functions.snapshot import (
+# fmt: off
+from dag_datalake_sirene.workflows.data_pipelines.elasticsearch.task_functions.snapshot\
+    import (
     snapshot_elastic_index,
     update_minio_current_index_version,
     delete_old_snapshots,
 )
 
-from dag_datalake_sirene.workflows.data_pipelines.elasticsearch.task_functions.downstream import (
+from dag_datalake_sirene.workflows.data_pipelines.elasticsearch.\
+    task_functions.downstream import (
     wait_for_downstream_import,
 )
+# fmt: on
 
 from dag_datalake_sirene.config import (
     EMAIL_LIST,
@@ -22,7 +26,7 @@ default_args = {
     "depends_on_past": False,
     "email": EMAIL_LIST,
     "email_on_failure": True,
-    "email_on_retry": True,
+    "email_on_retry": False,
     "retries": 0,
     "retry_delay": timedelta(minutes=5),
 }

--- a/workflows/data_pipelines/marche_inclusion/DAG.py
+++ b/workflows/data_pipelines/marche_inclusion/DAG.py
@@ -23,7 +23,7 @@ default_args = {
     "depends_on_past": False,
     "email_on_failure": True,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 1,
 }
 
 

--- a/workflows/data_pipelines/rne/database/DAG.py
+++ b/workflows/data_pipelines/rne/database/DAG.py
@@ -19,7 +19,7 @@ default_args = {
     "depends_on_past": False,
     "email": EMAIL_LIST,
     "email_on_failure": True,
-    "email_on_retry": True,
+    "email_on_retry": False,
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
 }

--- a/workflows/data_pipelines/rne/flux/DAG.py
+++ b/workflows/data_pipelines/rne/flux/DAG.py
@@ -14,7 +14,7 @@ default_args = {
     "depends_on_past": False,
     "email": EMAIL_LIST,
     "email_on_failure": True,
-    "email_on_retry": True,
+    "email_on_retry": False,
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
 }

--- a/workflows/data_pipelines/rne/stock/DAG.py
+++ b/workflows/data_pipelines/rne/stock/DAG.py
@@ -19,7 +19,7 @@ default_args = {
     "depends_on_past": False,
     "email": EMAIL_LIST,
     "email_on_failure": True,
-    "email_on_retry": True,
+    "email_on_retry": False,
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
 }

--- a/workflows/data_pipelines/sirene/flux/DAG.py
+++ b/workflows/data_pipelines/sirene/flux/DAG.py
@@ -31,7 +31,8 @@ default_args = {
     "depends_on_past": False,
     "email_on_failure": True,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
 }
 
 

--- a/workflows/maintenance/DAG_clean_logs_and_runs.py
+++ b/workflows/maintenance/DAG_clean_logs_and_runs.py
@@ -1,5 +1,4 @@
 from airflow.operators.python_operator import PythonOperator
-from airflow.operators.email_operator import EmailOperator
 from airflow.models import DAG
 from datetime import datetime, timedelta, timezone
 from airflow.models.dagrun import DagRun
@@ -8,7 +7,6 @@ import os
 import logging
 import shutil
 from dag_datalake_sirene.config import (
-    AIRFLOW_ENV,
     EMAIL_LIST,
 )
 
@@ -96,20 +94,5 @@ with DAG(
         task_id="delete_old_runs", python_callable=delete_old_runs, dag=dag
     )
 
-    success_email_body = f"""
-    Hi, <br><br>
-    delete-logs-and-runs-{AIRFLOW_ENV} DAG has
-    been executed successfully at {datetime.now()}.
-    """
-
-    send_email = EmailOperator(
-        task_id="send_email",
-        to=EMAIL_LIST,
-        subject=f"Airflow Success: DAG-{AIRFLOW_ENV}!",
-        html_content=success_email_body,
-        dag=dag,
-    )
-
     # Set the task dependency
     delete_old_runs_task.set_upstream(delete_old_logs_task)
-    send_email.set_upstream(delete_old_runs_task)

--- a/workflows/maintenance/DAG_clean_minio.py
+++ b/workflows/maintenance/DAG_clean_minio.py
@@ -1,6 +1,5 @@
 import logging
 from airflow.operators.python_operator import PythonOperator
-from airflow.operators.email_operator import EmailOperator
 from airflow.models import DAG
 from datetime import datetime, timedelta, timezone
 from dag_datalake_sirene.helpers.minio_helpers import minio_client
@@ -83,19 +82,5 @@ with DAG(
         },
         dag=dag,
     )
-    success_email_body = f"""
-    Hi, <br><br>
-    delete-old-files-from-MinIO-{AIRFLOW_ENV} DAG has
-    been executed successfully at {datetime.now()}.
-    """
-
-    send_email = EmailOperator(
-        task_id="send_email",
-        to=EMAIL_LIST,
-        subject=f"Airflow Success: DAG-{AIRFLOW_ENV}!",
-        html_content=success_email_body,
-        dag=dag,
-    )
 
     delete_old_sirene_databases.set_upstream(delete_old_rne_databases)
-    send_email.set_upstream(delete_old_sirene_databases)

--- a/workflows/maintenance/DAG_flush_and_execute_queries.py
+++ b/workflows/maintenance/DAG_flush_and_execute_queries.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from airflow.models import DAG
-from airflow.operators.email_operator import EmailOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 from dag_datalake_sirene.helpers.flush_cache import flush_cache
@@ -9,7 +8,6 @@ from dag_datalake_sirene.helpers.execute_slow_queries import (
     execute_slow_requests,
 )
 from dag_datalake_sirene.config import (
-    AIRFLOW_ENV,
     EMAIL_LIST,
     REDIS_HOST,
     REDIS_PORT,
@@ -23,7 +21,6 @@ default_args = {
     "depends_on_past": False,
     "email": EMAIL_LIST,
     "email_on_failure": True,
-    "email_on_retry": True,
 }
 
 with DAG(
@@ -52,19 +49,4 @@ with DAG(
         python_callable=execute_slow_requests,
     )
 
-    success_email_body = f"""
-    Hi, <br><br>
-    Flush cache ***{AIRFLOW_ENV}*** DAG has been executed successfully
-    at {datetime.now()}.
-    """
-
-    send_email = EmailOperator(
-        task_id="send_email",
-        to=EMAIL_LIST,
-        subject=f"Airflow Success: DAG-{AIRFLOW_ENV}!",
-        html_content=success_email_body,
-        dag=dag,
-    )
-
     execute_slow_requests.set_upstream(flush_cache)
-    send_email.set_upstream(execute_slow_requests)

--- a/workflows/maintenance/DAG_flush_cache_only.py
+++ b/workflows/maintenance/DAG_flush_cache_only.py
@@ -1,12 +1,10 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from airflow.models import DAG
-from airflow.operators.email_operator import EmailOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 from dag_datalake_sirene.helpers.flush_cache import flush_cache
 from dag_datalake_sirene.config import (
-    AIRFLOW_ENV,
     EMAIL_LIST,
     REDIS_HOST,
     REDIS_PORT,
@@ -20,7 +18,7 @@ default_args = {
     "depends_on_past": False,
     "email": EMAIL_LIST,
     "email_on_failure": True,
-    "email_on_retry": True,
+    "email_on_retry": False,
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
 }
@@ -44,19 +42,3 @@ with DAG(
             REDIS_PASSWORD,
         ),
     )
-
-    success_email_body = f"""
-    Hi, <br><br>
-    Flush cache ***{AIRFLOW_ENV}*** DAG has been executed
-    successfully at {datetime.now()}.
-    """
-
-    send_email = EmailOperator(
-        task_id="send_email",
-        to=EMAIL_LIST,
-        subject=f"Airflow Success: DAG-{AIRFLOW_ENV}!",
-        html_content=success_email_body,
-        dag=dag,
-    )
-
-    send_email.set_upstream(flush_cache)

--- a/workflows/maintenance/DAG_restart_api.py
+++ b/workflows/maintenance/DAG_restart_api.py
@@ -1,11 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from airflow.contrib.operators.ssh_operator import SSHOperator
 from airflow.models import DAG
-from airflow.operators.email_operator import EmailOperator
 from airflow.utils.dates import days_ago
 from dag_datalake_sirene.config import (
-    AIRFLOW_ENV,
     EMAIL_LIST,
     PATH_AIO,
 )
@@ -14,7 +12,7 @@ default_args = {
     "depends_on_past": False,
     "email": EMAIL_LIST,
     "email_on_failure": True,
-    "email_on_retry": True,
+    "email_on_retry": False,
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
 }
@@ -36,19 +34,3 @@ with DAG(
         cmd_timeout=60,
         dag=dag,
     )
-
-    success_email_body = f"""
-    Hi, <br><br>
-    Restarting API ***{AIRFLOW_ENV}*** DAG has been executed successfully at
-     {datetime.now()}.
-    """
-
-    send_email = EmailOperator(
-        task_id="send_email",
-        to=EMAIL_LIST,
-        subject=f"Airflow Success: DAG-{AIRFLOW_ENV}!",
-        html_content=success_email_body,
-        dag=dag,
-    )
-
-    send_email.set_upstream(restart_aio_container)


### PR DESCRIPTION
In this pull request, I've retained email notifications for failure scenarios, but I propose disabling notifications for successful executions of all DAGs except the main one. The main DAG will still trigger a Tchap notification update regardless of success or failure.