### PR TITLE
Dev : conf redis & no longer restart the API container

### DIFF
--- a/config.py
+++ b/config.py
@@ -73,9 +73,9 @@ PATH_AIO = Variable.get("PATH_AIO", None)
 COLOR_IS_DAILY = bool(Variable.get("COLOR_IS_DAILY", "False"))
 
 # Redis
-REDIS_HOST = "redis"
-REDIS_PORT = "6379"
-REDIS_DB = "0"
+REDIS_HOST = Variable.get("REDIS_HOST", "redis")
+REDIS_PORT = Variable.get("REDIS_PORT", "6379")
+REDIS_DB = Variable.get("REDIS_DB", "0")
 REDIS_PASSWORD = Variable.get("REDIS_PASSWORD", None)
 
 # ElasticSearch

--- a/workflows/data_pipelines/elasticsearch/DAG_index_data.py
+++ b/workflows/data_pipelines/elasticsearch/DAG_index_data.py
@@ -4,8 +4,6 @@ from airflow.models import DAG
 from airflow.operators.python import PythonOperator
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
-from airflow.contrib.operators.ssh_operator import SSHOperator
-
 from dag_datalake_sirene.helpers.flush_cache import flush_cache
 
 # fmt: off
@@ -168,14 +166,6 @@ with DAG(
         clean_folder.set_upstream([test_api, update_sitemap])
         send_notification_tchap.set_upstream([clean_folder, update_sitemap])
     else:
-        execute_aio_container = SSHOperator(
-            ssh_conn_id="SERVER",
-            task_id="execute_aio_container",
-            command=f"cd {PATH_AIO} "
-            f"&& docker-compose -f docker-compose-aio.yml up --build -d --force",
-            cmd_timeout=60,
-            dag=dag,
-        )
         flush_cache = PythonOperator(
             task_id="flush_cache",
             provide_context=True,
@@ -191,7 +181,6 @@ with DAG(
             task_id="clean_folder",
             folder_path=f"{AIRFLOW_DAG_TMP}{AIRFLOW_DAG_FOLDER}{AIRFLOW_ELK_DAG_NAME}",
         )
-        execute_aio_container.set_upstream(update_elastic_alias)
-        test_api.set_upstream(execute_aio_container)
+        test_api.set_upstream(update_elastic_alias)
         clean_folder.set_upstream([test_api, update_sitemap])
         flush_cache.set_upstream(clean_folder)

--- a/workflows/data_pipelines/elasticsearch/task_functions/snapshot.py
+++ b/workflows/data_pipelines/elasticsearch/task_functions/snapshot.py
@@ -89,6 +89,8 @@ def rollback_minio_current_index_version(**kwargs):
     if previous is None:
         raise Exception("No previous version found")
 
+    elastic_connection = connections.get_connection()
+
     snapshots = elastic_connection.snapshot.get(
         repository=ELASTIC_SNAPSHOT_REPOSITORY,
         snapshot=previous["current"]["snapshot"],


### PR DESCRIPTION
This PR introduces two changes : 
- it no longer assumes that the redis host is called 'redis'
- it no longer needs to restart the API container over SSH