### PR TITLE
[BUG][DATA-PIPELINES]Fix `elus` data processing

### DIFF
--- a/workflows/data_pipelines/etl/data_fetch_clean/collectivite_territoriale.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/collectivite_territoriale.py
@@ -124,12 +124,14 @@ def preprocess_elus_data(data_dir):
     df_elus_part.loc[df_elus_part["colter_code"] == "972", "colter_code"] = "02"
     df_elus_part.loc[df_elus_part["colter_code"] == "973", "colter_code"] = "03"
     elus = pd.concat([elus, df_elus_part])
+
     # Conseillers communautaires
     df_elus_epci = process_elus_files(
         URL_ELUS_EPCI,
         "N° SIREN",
     )
     elus = pd.concat([elus, df_elus_epci])
+
     # Conseillers municipaux
     df_elus_epci = process_elus_files(
         URL_CONSEILLERS_MUNICIPAUX,
@@ -161,7 +163,7 @@ def preprocess_elus_data(data_dir):
 
 
 def process_elus_files(url, colname):
-    df_elus = pd.read_csv(url, dtype=str)
+    df_elus = pd.read_csv(url, dtype=str, sep=";")
 
     column_mapping = {
         "Nom de l'élu": "nom_elu",

--- a/workflows/data_pipelines/etl/data_fetch_clean/collectivite_territoriale.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/collectivite_territoriale.py
@@ -164,6 +164,7 @@ def preprocess_elus_data(data_dir):
 
 def process_elus_files(url, colname):
     df_elus = pd.read_csv(url, dtype=str, sep=";")
+    df_elus.rename(columns=lambda x: x.replace("’", "'"), inplace=True)
 
     column_mapping = {
         "Nom de l'élu": "nom_elu",


### PR DESCRIPTION
closes #310 

This PR addresses issues resulting from recent updates to the `elus` files on _data.gouv,_ which caused failures in the ETL process. Here's a breakdown of the changes:

1. Added a delimiter to the pandas DataFrame: In some columns, commas were present, which caused confusion for the parser. By specifying a delimiter, the parser can properly distinguish between values and avoid errors.

2. Replaced single quotation marks with apostrophes: Certain column names contained single quotation marks instead of apostrophes. This inconsistency led to a bug during the column renaming process. By replacing the single quotation marks with apostrophes, the column names are standardized and the bug is resolved.