### PR TITLE
[DATA-PIPELINES][RNE]chore: increase RNE database dag timeout to 8 days

### DIFF
--- a/workflows/data_pipelines/rne/database/DAG.py
+++ b/workflows/data_pipelines/rne/database/DAG.py
@@ -31,7 +31,7 @@ with DAG(
     schedule_interval="0 2 * * *",  # Run daily at 2 am
     max_active_runs=1,
     catchup=False,
-    dagrun_timeout=timedelta(minutes=(60 * 100)),
+    dagrun_timeout=timedelta(minutes=(60 * 200)),
     tags=["rne", "database"],
     params={},
 ) as dag:


### PR DESCRIPTION
Extend the timeout period since the staging server's performance is lower compared to production.